### PR TITLE
Populating acts table when fetching lineups

### DIFF
--- a/migrations/0007_noisy_mephisto.sql
+++ b/migrations/0007_noisy_mephisto.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS "act" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"externalId" varchar(128) NOT NULL,
+	"showId" integer NOT NULL,
+	"comicId" integer NOT NULL,
+	"enabled" boolean,
+	"createdAt" timestamp DEFAULT now(),
+	CONSTRAINT "act_externalId_unique" UNIQUE("externalId")
+);
+--> statement-breakpoint
+ALTER TABLE "comic" ADD COLUMN "enabled" boolean;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "act" ADD CONSTRAINT "act_showId_show_id_fk" FOREIGN KEY ("showId") REFERENCES "public"."show"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "act" ADD CONSTRAINT "act_comicId_comic_id_fk" FOREIGN KEY ("comicId") REFERENCES "public"."comic"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "uniqueComicShow" ON "act" USING btree ("comicId","showId");

--- a/migrations/0008_same_slapstick.sql
+++ b/migrations/0008_same_slapstick.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "act" ALTER COLUMN "enabled" SET DEFAULT true;

--- a/migrations/0009_puzzling_serpent_society.sql
+++ b/migrations/0009_puzzling_serpent_society.sql
@@ -1,0 +1,17 @@
+ALTER TABLE "act" DROP CONSTRAINT "act_showId_show_id_fk";
+--> statement-breakpoint
+ALTER TABLE "act" DROP CONSTRAINT "act_comicId_comic_id_fk";
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "act" ADD CONSTRAINT "act_showId_show_id_fk" FOREIGN KEY ("showId") REFERENCES "public"."show"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "act" ADD CONSTRAINT "act_comicId_comic_id_fk" FOREIGN KEY ("comicId") REFERENCES "public"."comic"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "nameUniqueIndex" ON "comic" USING btree (lower("name"));

--- a/migrations/meta/0007_snapshot.json
+++ b/migrations/meta/0007_snapshot.json
@@ -1,0 +1,391 @@
+{
+  "id": "890fffd7-f00e-4ca6-a879-313535c0207a",
+  "prevId": "15bbdfb5-b4bd-4984-ba61-04283f1e7f08",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.act": {
+      "name": "act",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "showId": {
+          "name": "showId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comicId": {
+          "name": "comicId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniqueComicShow": {
+          "name": "uniqueComicShow",
+          "columns": [
+            {
+              "expression": "comicId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "showId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "act_showId_show_id_fk": {
+          "name": "act_showId_show_id_fk",
+          "tableFrom": "act",
+          "tableTo": "show",
+          "columnsFrom": [
+            "showId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "act_comicId_comic_id_fk": {
+          "name": "act_comicId_comic_id_fk",
+          "tableFrom": "act",
+          "tableTo": "comic",
+          "columnsFrom": [
+            "comicId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "act_externalId_unique": {
+          "name": "act_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "externalId"
+          ]
+        }
+      }
+    },
+    "public.comic": {
+      "name": "comic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "img": {
+          "name": "img",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comic_externalId_unique": {
+          "name": "comic_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "externalId"
+          ]
+        },
+        "comic_name_unique": {
+          "name": "comic_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.room": {
+      "name": "room",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "room_externalId_unique": {
+          "name": "room_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "externalId"
+          ]
+        },
+        "room_name_unique": {
+          "name": "room_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.show": {
+      "name": "show",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roomId": {
+          "name": "roomId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover": {
+          "name": "cover",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "show_roomId_room_id_fk": {
+          "name": "show_roomId_room_id_fk",
+          "tableFrom": "show",
+          "tableTo": "room",
+          "columnsFrom": [
+            "roomId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "show_externalId_unique": {
+          "name": "show_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "externalId"
+          ]
+        }
+      }
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "emailUniqueIndex": {
+          "name": "emailUniqueIndex",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_externalId_unique": {
+          "name": "user_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "externalId"
+          ]
+        },
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/0008_snapshot.json
+++ b/migrations/meta/0008_snapshot.json
@@ -1,0 +1,392 @@
+{
+  "id": "77529be6-5668-4173-bece-5fe5995b1e95",
+  "prevId": "890fffd7-f00e-4ca6-a879-313535c0207a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.act": {
+      "name": "act",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "showId": {
+          "name": "showId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comicId": {
+          "name": "comicId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniqueComicShow": {
+          "name": "uniqueComicShow",
+          "columns": [
+            {
+              "expression": "comicId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "showId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "act_showId_show_id_fk": {
+          "name": "act_showId_show_id_fk",
+          "tableFrom": "act",
+          "tableTo": "show",
+          "columnsFrom": [
+            "showId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "act_comicId_comic_id_fk": {
+          "name": "act_comicId_comic_id_fk",
+          "tableFrom": "act",
+          "tableTo": "comic",
+          "columnsFrom": [
+            "comicId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "act_externalId_unique": {
+          "name": "act_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "externalId"
+          ]
+        }
+      }
+    },
+    "public.comic": {
+      "name": "comic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "img": {
+          "name": "img",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comic_externalId_unique": {
+          "name": "comic_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "externalId"
+          ]
+        },
+        "comic_name_unique": {
+          "name": "comic_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.room": {
+      "name": "room",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "room_externalId_unique": {
+          "name": "room_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "externalId"
+          ]
+        },
+        "room_name_unique": {
+          "name": "room_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.show": {
+      "name": "show",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roomId": {
+          "name": "roomId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover": {
+          "name": "cover",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "show_roomId_room_id_fk": {
+          "name": "show_roomId_room_id_fk",
+          "tableFrom": "show",
+          "tableTo": "room",
+          "columnsFrom": [
+            "roomId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "show_externalId_unique": {
+          "name": "show_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "externalId"
+          ]
+        }
+      }
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "emailUniqueIndex": {
+          "name": "emailUniqueIndex",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_externalId_unique": {
+          "name": "user_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "externalId"
+          ]
+        },
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/0009_snapshot.json
+++ b/migrations/meta/0009_snapshot.json
@@ -1,0 +1,408 @@
+{
+  "id": "703b4bc4-cf9b-421d-aa96-ba5528883d21",
+  "prevId": "77529be6-5668-4173-bece-5fe5995b1e95",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.act": {
+      "name": "act",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "showId": {
+          "name": "showId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comicId": {
+          "name": "comicId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniqueComicShow": {
+          "name": "uniqueComicShow",
+          "columns": [
+            {
+              "expression": "comicId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "showId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "act_showId_show_id_fk": {
+          "name": "act_showId_show_id_fk",
+          "tableFrom": "act",
+          "tableTo": "show",
+          "columnsFrom": [
+            "showId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "act_comicId_comic_id_fk": {
+          "name": "act_comicId_comic_id_fk",
+          "tableFrom": "act",
+          "tableTo": "comic",
+          "columnsFrom": [
+            "comicId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "act_externalId_unique": {
+          "name": "act_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "externalId"
+          ]
+        }
+      }
+    },
+    "public.comic": {
+      "name": "comic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "img": {
+          "name": "img",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nameUniqueIndex": {
+          "name": "nameUniqueIndex",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comic_externalId_unique": {
+          "name": "comic_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "externalId"
+          ]
+        },
+        "comic_name_unique": {
+          "name": "comic_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.room": {
+      "name": "room",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "room_externalId_unique": {
+          "name": "room_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "externalId"
+          ]
+        },
+        "room_name_unique": {
+          "name": "room_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.show": {
+      "name": "show",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roomId": {
+          "name": "roomId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover": {
+          "name": "cover",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "show_roomId_room_id_fk": {
+          "name": "show_roomId_room_id_fk",
+          "tableFrom": "show",
+          "tableTo": "room",
+          "columnsFrom": [
+            "roomId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "show_externalId_unique": {
+          "name": "show_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "externalId"
+          ]
+        }
+      }
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "emailUniqueIndex": {
+          "name": "emailUniqueIndex",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_externalId_unique": {
+          "name": "user_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "externalId"
+          ]
+        },
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -50,6 +50,27 @@
       "when": 1727589358177,
       "tag": "0006_marvelous_scalphunter",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1727630335389,
+      "tag": "0007_noisy_mephisto",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1727644378168,
+      "tag": "0008_same_slapstick",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1727651765213,
+      "tag": "0009_puzzling_serpent_society",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/handleLineUp.ts
+++ b/packages/core/handleLineUp.ts
@@ -1,7 +1,8 @@
-import { createComics } from "./models/comic";
 import { fetchLineUp } from "./fetchLineUp";
-import { Lineup } from "./models/act";
 import { isValidComic } from "./sql/comic.sql";
+import { createComics, getComicsByNames } from "./models/comic";
+import { createActs, Lineup } from "./models/act";
+import { getShowByTimestamp } from "./models/show";
 
 export const handleLineUp = async ({ date }: { date: string }) => {
   const lineUpsData = await fetchLineUp(date);
@@ -20,6 +21,22 @@ export const handleLineUp = async ({ date }: { date: string }) => {
     });
     if (uniqueComics.length) {
       await createComics(uniqueComics);
+    }
+
+    for (const lineup of [lineUps[0]]) {
+      const { timestamp, acts } = lineup;
+      const actNames = acts.filter((act) => act.name).map((act) => act.name);
+      const [show, comics] = await Promise.all([
+        getShowByTimestamp(timestamp),
+        getComicsByNames(actNames),
+      ]);
+      if (show.length === 1 && show[0].id) {
+        const newActs = comics.map(({ id }) => ({
+          comicId: id,
+          showId: show[0].id,
+        }));
+        await createActs(newActs);
+      }
     }
   } catch (e) {
     // Swallowing Error here bc this code is just for background caching

--- a/packages/core/models/act.ts
+++ b/packages/core/models/act.ts
@@ -1,7 +1,12 @@
 import { InsertAct, act, SelectAct } from "@core/sql/act.sql";
+import { PgDialect } from "drizzle-orm/pg-core";
+
 import { ApiResponse } from "../../types/api";
 import { db } from "@core/database";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
+import { show } from "@core/sql/show.sql";
+import { comic } from "@core/sql/comic.sql";
+const pgDialect = new PgDialect();
 
 const COMEDY_CELLAR_URL = "https://www.comedycellar.com";
 
@@ -62,3 +67,20 @@ export async function getLineupByExternalId(
 ) {
   return db.select().from(act).where(eq(act.externalId, externalId));
 }
+
+// WIP
+// export async function createActsFromRawData({
+//   timestamp,
+//   comicName,
+// }: {
+//   timestamp: number;
+//   comicName: string[];
+// }) {
+//   const query = sql`INSERT INTO ${act} (${act.comicId.name}, ${act.showId.name}) SELECT ${comic.id}, ${show.id} FROM ${show} JOIN ${comic} ON ${comic.name} IN ${comicName} WHERE ${show.timestamp} = ${timestamp}`;
+//   console.log(pgDialect.sqlToQuery(query));
+
+//   return db.insert()
+
+//   // return null;
+//   return db.execute(query);
+// }

--- a/packages/core/models/comic.ts
+++ b/packages/core/models/comic.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { db } from "@core/database";
 import { comic, InsertComic, SelectComic } from "@core/sql/comic.sql";
 import { COMIC_PREFIX } from "@core/common/constants";
@@ -21,4 +21,12 @@ export async function getComicByExternalId(
   externalId: SelectComic["externalId"]
 ) {
   return db.select().from(comic).where(eq(comic.externalId, externalId));
+}
+
+export async function getComicByName(name: SelectComic["name"]) {
+  return getComicsByNames([name]);
+}
+
+export async function getComicsByNames(names: SelectComic["name"][]) {
+  return db.select().from(comic).where(inArray(comic.name, names));
 }

--- a/packages/core/models/show.ts
+++ b/packages/core/models/show.ts
@@ -136,3 +136,7 @@ export async function getShowByExternalId(
 ) {
   return db.select().from(show).where(eq(show.externalId, externalId));
 }
+
+export async function getShowByTimestamp(timestamp: SelectShow["timestamp"]) {
+  return db.select().from(show).where(eq(show.timestamp, timestamp));
+}

--- a/packages/core/sql/act.sql.ts
+++ b/packages/core/sql/act.sql.ts
@@ -23,12 +23,12 @@ export const act = pgTable(
       .notNull()
       .unique(),
     showId: integer("showId")
-      .references(() => show.id)
+      .references(() => show.id, { onDelete: "cascade" })
       .notNull(),
     comicId: integer("comicId")
-      .references(() => comic.id)
+      .references(() => comic.id, { onDelete: "cascade" })
       .notNull(),
-    enabled: boolean("enabled"),
+    enabled: boolean("enabled").default(true),
     createdAt: timestamp("createdAt").defaultNow(),
   },
   (table) => ({

--- a/packages/core/sql/comic.sql.ts
+++ b/packages/core/sql/comic.sql.ts
@@ -5,25 +5,34 @@ import {
   timestamp,
   pgTable,
   boolean,
+  uniqueIndex,
 } from "drizzle-orm/pg-core";
 import { createExternalId } from "../common/createExternalId";
 import { COMIC_PREFIX } from "../common/constants";
-import { relations } from "drizzle-orm";
+import { relations, sql } from "drizzle-orm";
 import { act } from "./act.sql";
 
-export const comic = pgTable("comic", {
-  id: serial("id").notNull().primaryKey(),
-  externalId: varchar("externalId", { length: 128 })
-    .$defaultFn(() => createExternalId(COMIC_PREFIX))
-    .notNull()
-    .unique(),
-  img: text("img").notNull(),
-  name: text("name").notNull().unique(),
-  description: text("description"),
-  website: text("website"),
-  enabled: boolean("enabled"),
-  createdAt: timestamp("createdAt").defaultNow(),
-});
+export const comic = pgTable(
+  "comic",
+  {
+    id: serial("id").notNull().primaryKey(),
+    externalId: varchar("externalId", { length: 128 })
+      .$defaultFn(() => createExternalId(COMIC_PREFIX))
+      .notNull()
+      .unique(),
+    img: text("img").notNull(),
+    name: text("name").notNull().unique(),
+    description: text("description"),
+    website: text("website"),
+    enabled: boolean("enabled"),
+    createdAt: timestamp("createdAt").defaultNow(),
+  },
+  (table) => ({
+    nameUniqueIndex: uniqueIndex("nameUniqueIndex").on(
+      sql`lower(${table.name})`
+    ),
+  })
+);
 
 export const comicRelations = relations(comic, ({ many }) => ({
   acts: many(act),


### PR DESCRIPTION
Updated acts table to set enabled to true by default

Update Acts table to cascade deletes for shows and comics

Applied db migrations to db

adding acts per show to `act` table

added functions for fetching comics by their name

Added function for fetching show by timestamp