### PR TITLE
added db url to reservation lambda

### DIFF
--- a/infra/api.ts
+++ b/infra/api.ts
@@ -68,7 +68,7 @@ api.route("GET /api/line-up", {
 // ---- Reservations -----
 
 api.route("POST /api/reservation/{timestamp}", {
-  link: Object.values(emailSecrets),
+  link: [dbCreds.dbUrl, ...Object.values(emailSecrets)],
   handler: `${functionDir}/reservation.create`,
   environment: {
     STAGE: $app.stage,


### PR DESCRIPTION
This update adds the database connection string secret to the create reservation lambda function. Previously, this function was attempting to access the database connection without the necessary secret linked, resulting in an undefined value when invoked. Tho it doesn't use the db connection the connection is global

Changes Made:

Added the database connection string secret to the create reservation lambda function.