### PR TITLE
Feature/comic show count

### DIFF
--- a/packages/core/models/show.ts
+++ b/packages/core/models/show.ts
@@ -5,8 +5,10 @@ import {
   desc,
   eq,
   getTableColumns,
+  gt,
   gte,
   lte,
+  min,
   SQL,
   sql,
 } from "drizzle-orm";
@@ -255,4 +257,13 @@ export async function getShowByTimestamp(timestamp: SelectShow["timestamp"]) {
 
 export async function getLastShow(): Promise<SelectShow[] | []> {
   return db.select().from(show).orderBy(desc(show.timestamp)).limit(1);
+}
+
+export async function getUpcomingShow(): Promise<SelectShow[] | []> {
+  return db
+    .select()
+    .from(show)
+    .where(gt(show.timestamp, sql`CAST(EXTRACT(EPOCH FROM NOW()) AS INTEGER)`))
+    .orderBy(show.timestamp)
+    .limit(1);
 }

--- a/packages/frontend/src/pages/Comics/ComicList.tsx
+++ b/packages/frontend/src/pages/Comics/ComicList.tsx
@@ -1,6 +1,7 @@
-import { GlobeAltIcon } from "@heroicons/react/20/solid";
+import { LinkIcon } from "@heroicons/react/24/outline";
 import { Comic } from "../../types";
 import { Img } from "../../components/Image";
+import { ShowCount } from "./ShowCount";
 
 function ComicItem({ comic }: { comic: Comic }) {
   return (
@@ -16,9 +17,12 @@ function ComicItem({ comic }: { comic: Comic }) {
           className="aspect-[3/2] w-full rounded-lg object-cover"
         />
         <div className="flex-col grow-1 justify-between p-4">
-          <h3 className="text-lg font-semibold leading-8 tracking-tight text-gray-900">
-            {comic.name}
-          </h3>
+          <div className="flex items-center space-x-2">
+            <h3 className="text-lg font-semibold leading-8 tracking-tight text-gray-900">
+              {comic.name}
+            </h3>
+            <ShowCount showCount={comic.showCount ?? 0} />
+          </div>
           <p className="text-base leading-7 text-gray-600 line-clamp-4">
             {comic.description}
           </p>
@@ -30,7 +34,7 @@ function ComicItem({ comic }: { comic: Comic }) {
                 className="text-gray-400 hover:text-gray-500"
               >
                 <span className="sr-only">Website</span>
-                <GlobeAltIcon aria-hidden="true" className="h-5 w-5 " />
+                <LinkIcon aria-hidden="true" className="h-5 w-5" />
               </a>
             </li>
           </ul>

--- a/packages/frontend/src/pages/Comics/ShowCount.tsx
+++ b/packages/frontend/src/pages/Comics/ShowCount.tsx
@@ -1,0 +1,57 @@
+import { FireIcon } from "@heroicons/react/20/solid";
+import { FireIcon as EmptyFire } from "@heroicons/react/24/outline";
+import { SlashIcon } from "@heroicons/react/24/outline";
+
+export function ActivityIcon() {
+  return <FireIcon className="h-5 w-5 fill-yellow-400 stroke-orange-300" />;
+}
+
+export function ShowCount({ showCount }: { showCount: number }) {
+  if (showCount > 0) {
+    const iconCount = showCount > 8 ? 3 : showCount >= 5 ? 2 : 1;
+    return (
+      <div className="flex items-center">
+        {[...Array(iconCount)].map((_, index) => (
+          <ActivityIcon key={index} />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="">
+      <FireIcon className="h-5 w-5 fill-neutral-400" />
+    </div>
+  );
+}
+
+export function Legend() {
+  return (
+    <div className="flex flex-col sm:flex-row item-center sm:space-x-2">
+      <div className="flex items-center">
+        <div className="relative fill-neutral-400">
+          <FireIcon className="h-5 w-5 fill-neutral-400" />
+        </div>
+        <span className="ml-2">No Shows</span>
+      </div>
+      <span className="hidden sm:block"> | </span>
+      <div className="flex items-center">
+        <ActivityIcon />
+        <span className="ml-2">1-4 Shows</span>
+      </div>
+      <span className="hidden sm:block"> | </span>{" "}
+      <div className="flex items-center">
+        <ActivityIcon />
+        <ActivityIcon />
+        <span className="ml-2">5-8 Shows</span>
+      </div>
+      <span className="hidden sm:block"> | </span>{" "}
+      <div className="flex items-center">
+        <ActivityIcon />
+        <ActivityIcon />
+        <ActivityIcon />
+        <span className="ml-2">9+ Shows</span>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/pages/Comics/index.tsx
+++ b/packages/frontend/src/pages/Comics/index.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "react-query";
 import { Comic } from "../../types";
 import { fetchComics } from "../../utils/api";
 import { ComicList } from "./ComicList";
+import { Legend } from "./ShowCount";
 
 export default function Comics() {
   const { data, isFetching } = useQuery<Comic[]>(
@@ -17,5 +18,13 @@ export default function Comics() {
     }
   );
 
-  return <ComicList comics={data} isLoading={isFetching} />;
+  return (
+    <div className="flex flex-col space-y-4">
+      <div className="flex flex-col p-4 rounded-lg ring-1 ring-gray-200 shadow hover:shadow-md">
+        <h6 className="text-md font-bold">Upcoming shows</h6>
+        <Legend />
+      </div>
+      <ComicList comics={data} isLoading={isFetching} />
+    </div>
+  );
 }

--- a/packages/frontend/src/types.ts
+++ b/packages/frontend/src/types.ts
@@ -48,6 +48,7 @@ export type Comic = {
   website?: string;
   description: string;
   createdAt: string;
+  showCount?: number;
 };
 
 export type ShowDb = {


### PR DESCRIPTION
1. Updated fetch comics endpoint to return upcoming show counter per comic for the dates between now and the last know date for a show
2. Added function for fetching the next show
3. Added UI to show count via icons.
4. Added legend to comic page to explain flames