### PR TITLE
Re-skin shared components + add component gallery (Wave 0B-0D)

### DIFF
--- a/packages/frontend/src/components/Button.tsx
+++ b/packages/frontend/src/components/Button.tsx
@@ -4,6 +4,7 @@ import clsx from "clsx";
 
 interface CustomButtonProps {
   size?: "xs" | "sm" | "md" | "lg" | "xl";
+  variant?: "solid" | "outline" | "reserve";
 }
 
 // Use Preact's JSXInternal.HTMLAttributes for button element attributes
@@ -15,6 +16,7 @@ type ButtonProps = CustomButtonProps &
 
 export const Button: FunctionalComponent<ButtonProps> = ({
   size = "md",
+  variant = "solid",
   className,
   children,
   disabled,
@@ -22,7 +24,15 @@ export const Button: FunctionalComponent<ButtonProps> = ({
   ...props
 }) => {
   const baseClasses =
-    "rounded-sm bg-white text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 hover:bg-gray-50 font-semibold";
+    "rounded-pill font-sans font-semibold transition";
+
+  const variantClasses = {
+    solid: "bg-solid text-solid-fg hover:bg-solid-hover",
+    outline:
+      "bg-surface text-text border-hair border-line hover:bg-brand hover:text-brand-fg",
+    reserve:
+      "bg-solid text-solid-fg hover:bg-brand hover:text-brand-fg",
+  };
 
   const sizeClasses = {
     xs: "px-2 py-1 text-xs",
@@ -34,13 +44,14 @@ export const Button: FunctionalComponent<ButtonProps> = ({
 
   const buttonClasses = clsx(
     baseClasses,
+    variantClasses[variant],
     sizeClasses[size],
     disabled && "opacity-50 cursor-not-allowed",
     className
   );
 
   return (
-    <button type={type} className={buttonClasses} {...props}>
+    <button type={type} className={buttonClasses} disabled={disabled} {...props}>
       {children}
     </button>
   );

--- a/packages/frontend/src/components/Card.tsx
+++ b/packages/frontend/src/components/Card.tsx
@@ -1,6 +1,13 @@
 import * as Preact from "preact";
+import clsx from "clsx";
 
-export function Card({ children }: { children: React.ReactNode }) {
+export function Card({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
   const childrenArray = Preact.toChildArray(children);
   const headers = childrenArray
     .filter(
@@ -21,7 +28,12 @@ export function Card({ children }: { children: React.ReactNode }) {
     )
     .filter((child) => child.type === CardFooter);
   return (
-    <div className="divide-y divide-gray-200 overflow-hidden rounded-lg bg-white shadow-sm">
+    <div
+      className={clsx(
+        "divide-y divide-line overflow-hidden rounded-panel border-hair border-line bg-surface shadow-block-md",
+        className
+      )}
+    >
       {headers.map((header) => header)}
       {body.map((body) => body)}
       {footer.map((footer) => footer)}

--- a/packages/frontend/src/components/Checkbox.tsx
+++ b/packages/frontend/src/components/Checkbox.tsx
@@ -1,4 +1,5 @@
 import clsx from "clsx";
+
 type CheckboxProps = {
   label: string;
   displayLabel: string;
@@ -19,18 +20,18 @@ export function Checkbox({
   return (
     <div className="flex gap-3">
       <div className="flex h-6 shrink-0 items-center">
-        <div className="group grid size-4 grid-cols-1">
+        <div className="group relative grid size-6 grid-cols-1">
           <input
             id={label}
             name={label}
             type="checkbox"
             aria-describedby={`${label}-description`}
             className={clsx(
-              "col-start-1 row-start-1 appearance-none rounded-sm",
-              "border border-gray-300 bg-white",
-              "checked:border-primary checked:bg-primary indeterminate:border-primary indeterminate:bg-primary",
-              "focus-visible:bg-primary focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
-              "disabled:border-gray-300 disabled:bg-gray-100 disabled:checked:bg-gray-100 forced-colors:appearance-auto"
+              "peer col-start-1 row-start-1 size-6 appearance-none rounded-[5px]",
+              "border-hair border-line bg-surface",
+              "checked:bg-brand",
+              "focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand",
+              "disabled:cursor-not-allowed disabled:opacity-50 forced-colors:appearance-auto"
             )}
             checked={checked}
             defaultChecked={defaultChecked}
@@ -40,13 +41,27 @@ export function Checkbox({
                 : undefined
             }
           />
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 16 16"
+            fill="none"
+            className="pointer-events-none invisible col-start-1 row-start-1 size-4 justify-self-center self-center text-ink peer-checked:visible"
+          >
+            <path
+              d="M3 8.5L6.5 12L13 4"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
         </div>
       </div>
-      <div className="text-sm/6">
-        <label htmlFor={label} className="font-medium text-gray-900">
+      <div className="text-body">
+        <label htmlFor={label} className="font-medium text-text">
           {displayLabel}
         </label>
-        <p id={`${label}-description`} className="text-gray-500">
+        <p id={`${label}-description`} className="text-muted">
           {description}
         </p>
       </div>

--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -1,7 +1,9 @@
 import { getToday } from "../utils/date";
 import { clerk } from "../utils/clerk";
 import { Link } from "../components/Link";
+import { Perforation } from "./Perforation";
 import { useEffect, useState } from "preact/hooks";
+import clsx from "clsx";
 
 const navigation = [
   { name: "Home", href: `/?date=${getToday()}` },
@@ -29,26 +31,46 @@ export function Header() {
   }, []);
 
   return (
-    <header className="flex h-16 border-b border-gray-900/10 bg-primary">
-      <div className="mx-auto flex w-full max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
-        <div className="flex flex-1 items-center gap-x-6">
-          <a href="/" className="p-1.5">
-            <span className="sr-only">Comedy Cellar NYC Schedule</span>
-            <img
-              className="h-10 w-auto"
-              src="https://www.comedycellar.com/wp-content/uploads/2023/03/TheComedyCellar_Famous_1981_logo_light.svg"
-              alt=""
-            />
-          </a>
-        </div>
-        <nav className="flex text-xs gap-x-2 md:gap-x-8 md:text-sm font-semibold md:leading-6 md:text-black">
-          {navLinks.map((item, itemIdx) => (
-            <Link key={itemIdx} href={item.href} className="text-slate-950">
-              {item.name}
-            </Link>
-          ))}
+    <>
+      <header className="flex w-full items-center justify-between bg-brand px-5 py-4 sm:px-10">
+        <a href="/" className="flex items-baseline">
+          <span className="font-display text-d-md leading-none tracking-tightcap text-ink">
+            COMEDY CELLAR
+          </span>
+          <span className="ml-2.5 font-mono text-eyebrow tracking-mega text-ink/60">
+            EST. NYC 1981
+          </span>
+        </a>
+        <nav className="flex items-center gap-x-6">
+          {navLinks.map((item, itemIdx) => {
+            const isLast = itemIdx === navLinks.length - 1;
+            const isAuthAction = item.name === "Sign In" || item.name === "Sign out";
+
+            if (isLast && isAuthAction) {
+              return (
+                <Link
+                  key={itemIdx}
+                  href={item.href}
+                  className="rounded-pill bg-ink px-4 py-2 font-sans text-sm font-bold text-brand hover:bg-solid-hover hover:no-underline"
+                >
+                  {item.name}
+                </Link>
+              );
+            }
+
+            return (
+              <Link
+                key={itemIdx}
+                href={item.href}
+                className={clsx("font-sans text-body font-medium text-ink opacity-[.78]")}
+              >
+                {item.name}
+              </Link>
+            );
+          })}
         </nav>
-      </div>
-    </header>
+      </header>
+      <Perforation />
+    </>
   );
 }

--- a/packages/frontend/src/components/Input.tsx
+++ b/packages/frontend/src/components/Input.tsx
@@ -1,8 +1,19 @@
-export function Input(props) {
+import { JSX } from "preact";
+
+import clsx from "clsx";
+
+type InputProps = JSX.HTMLAttributes<HTMLInputElement>;
+
+export function Input({ className, ...props }: InputProps) {
   return (
     <input
       {...props}
-      className="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
+      className={clsx(
+        "block w-full bg-surface text-text border-hair border-line rounded-field px-3.5 py-3",
+        "font-sans text-body placeholder:text-placeholder outline-none",
+        "focus:shadow-[3px_3px_0_#F3C44C]",
+        className
+      )}
     />
   );
 }

--- a/packages/frontend/src/components/Link.tsx
+++ b/packages/frontend/src/components/Link.tsx
@@ -6,6 +6,7 @@ type LinkProps = JSX.HTMLAttributes<HTMLAnchorElement> & {
   href: string;
   target?: string;
   rel?: string;
+  variant?: "default" | "underline";
 };
 
 export const Link: FunctionalComponent<LinkProps> = ({
@@ -14,11 +15,18 @@ export const Link: FunctionalComponent<LinkProps> = ({
   href,
   target,
   rel,
+  variant = "default",
   ...props
 }) => {
-  const baseClasses = "font-small text-blue-600 hover:underline";
+  const baseClasses = "font-sans";
 
-  const linkClasses = clsx(baseClasses, className);
+  const variantClasses = {
+    default: "text-text hover:underline",
+    underline:
+      "inline text-text no-underline border-b-2 border-brand pb-0.5 hover:border-brand-hover",
+  };
+
+  const linkClasses = clsx(baseClasses, variantClasses[variant], className);
 
   return (
     <a className={linkClasses} href={href} target={target} rel={rel} {...props}>

--- a/packages/frontend/src/components/Perforation.tsx
+++ b/packages/frontend/src/components/Perforation.tsx
@@ -1,0 +1,23 @@
+import { FunctionalComponent } from "preact";
+
+/**
+ * Ticket-edge motif: a thin dark ink band with a repeating dotted yellow
+ * pattern, evoking the perforated tear-line along a ticket stub.
+ *
+ * brand (#F3C44C) and ink (#1A1714) are theme-constant, so hardcoding them
+ * here (per the design spec) is correct — they do not flip in dark mode.
+ */
+export const Perforation: FunctionalComponent = () => {
+  return (
+    <div
+      aria-hidden="true"
+      className="h-3.5 w-full"
+      style={{
+        background: "#1A1714",
+        backgroundImage:
+          "radial-gradient(circle at center, #F3C44C 2.2px, transparent 2.8px)",
+        backgroundSize: "20px 14px",
+      }}
+    />
+  );
+};

--- a/packages/frontend/src/components/Spinner.tsx
+++ b/packages/frontend/src/components/Spinner.tsx
@@ -9,7 +9,7 @@ export function Spinner({ className, size }: SpinnerProps = { size: 5 }) {
   const spinnerSize = `h-${size} w-${size}`;
   return (
     <svg
-      className={clsx("animate-spin text-black", className, spinnerSize)}
+      className={clsx("animate-spin text-text", className, spinnerSize)}
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"

--- a/packages/frontend/src/components/ThemeToggle.tsx
+++ b/packages/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,32 @@
+import { FunctionalComponent } from "preact";
+
+import clsx from "clsx";
+
+import { useTheme } from "../hooks/useTheme";
+
+type ThemeToggleProps = {
+  className?: string;
+};
+
+export const ThemeToggle: FunctionalComponent<ThemeToggleProps> = ({ className }) => {
+  const { theme, toggle } = useTheme();
+
+  const isDark = theme === "dark";
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+      className={clsx(
+        "fixed bottom-6 right-6 z-50",
+        "grid h-11 w-11 place-items-center",
+        "bg-surface border-hair border-line rounded-pill shadow-block",
+        "hover:bg-brand hover:text-brand-fg transition",
+        className,
+      )}
+    >
+      <span aria-hidden="true">{isDark ? "☾" : "☀"}</span>
+    </button>
+  );
+};

--- a/packages/frontend/src/components/ui/Avatar.tsx
+++ b/packages/frontend/src/components/ui/Avatar.tsx
@@ -1,0 +1,63 @@
+import clsx from "clsx";
+
+/**
+ * 6-pair avatar swatch rotation (bg/fg), theme-constant per plan/README.md:
+ * "Comic/avatar swatch rotation: #F3C44C/#1A1714, #E7E0CF/#1A1714, #1A1714/#F3C44C,
+ *  #E9C9A0/#1A1714, #D9CDB6/#1A1714, #2B2722/#FBF6EC (bg/fg pairs)"
+ * Kept local to this file (src/utils/swatches.ts does not exist yet); if/when that
+ * shared module lands, this component can switch to importing getSwatch/getInitials
+ * from it without changing the public API below.
+ */
+const SWATCHES: { bg: string; fg: string }[] = [
+  { bg: "#F3C44C", fg: "#1A1714" },
+  { bg: "#E7E0CF", fg: "#1A1714" },
+  { bg: "#1A1714", fg: "#F3C44C" },
+  { bg: "#E9C9A0", fg: "#1A1714" },
+  { bg: "#D9CDB6", fg: "#1A1714" },
+  { bg: "#2B2722", fg: "#FBF6EC" },
+];
+
+function getSwatch(name: string): { bg: string; fg: string } {
+  const key = name || "";
+  let hash = 0;
+  for (let i = 0; i < key.length; i++) {
+    hash = (hash * 31 + key.charCodeAt(i)) | 0;
+  }
+  const index = Math.abs(hash) % SWATCHES.length;
+  return SWATCHES[index];
+}
+
+function getInitials(name: string): string {
+  const words = (name || "").trim().split(/\s+/).filter(Boolean).slice(0, 2);
+  if (words.length === 0) return "";
+  return words.map((word) => word[0]!.toUpperCase()).join("");
+}
+
+export interface AvatarProps {
+  name: string;
+  size?: number;
+  className?: string;
+}
+
+export function Avatar({ name, size = 42, className }: AvatarProps) {
+  const { bg, fg } = getSwatch(name);
+  const initials = getInitials(name);
+
+  return (
+    <span
+      className={clsx(
+        "grid place-items-center shrink-0 rounded-pill border-hair border-line font-display",
+        className,
+      )}
+      style={{
+        width: size,
+        height: size,
+        fontSize: size * 0.4,
+        backgroundColor: bg,
+        color: fg,
+      }}
+    >
+      {initials}
+    </span>
+  );
+}

--- a/packages/frontend/src/components/ui/Eyebrow.tsx
+++ b/packages/frontend/src/components/ui/Eyebrow.tsx
@@ -1,0 +1,21 @@
+import { FunctionalComponent, ComponentChildren } from "preact";
+
+import clsx from "clsx";
+
+type EyebrowProps = {
+  className?: string;
+  children: ComponentChildren;
+};
+
+export const Eyebrow: FunctionalComponent<EyebrowProps> = ({ className, children }) => {
+  return (
+    <p
+      className={clsx(
+        "font-mono uppercase text-eyebrow tracking-mega text-gold",
+        className,
+      )}
+    >
+      {children}
+    </p>
+  );
+};

--- a/packages/frontend/src/components/ui/FlameMeter.tsx
+++ b/packages/frontend/src/components/ui/FlameMeter.tsx
@@ -1,0 +1,41 @@
+import clsx from "clsx";
+
+export interface FlameMeterProps {
+  level: number;
+  className?: string;
+}
+
+const FLAME_ON = "#D8841E";
+const FLAME_OFF = "#E6DECB";
+
+/** Bar heights: short / medium / tall. */
+const BAR_HEIGHTS = ["6px", "9px", "12px"];
+
+/**
+ * Comics heat meter — three vertical bars indicating a comic's upcoming-show
+ * heat tier. Bar i is lit (flame-on) when i <= level. Colors are
+ * theme-constant per design handoff.
+ */
+export function FlameMeter({ level, className }: FlameMeterProps) {
+  const clamped = Math.min(3, Math.max(0, Math.round(level)));
+
+  return (
+    <div
+      className={clsx("inline-flex items-end gap-0.5", className)}
+      role="img"
+      aria-label={`${clamped} of 3 heat`}
+    >
+      {BAR_HEIGHTS.map((height, i) => (
+        <span
+          key={i}
+          style={{
+            width: "4px",
+            height,
+            backgroundColor: i < clamped ? FLAME_ON : FLAME_OFF,
+          }}
+          className="rounded-[1px]"
+        />
+      ))}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/ui/PageHeader.tsx
+++ b/packages/frontend/src/components/ui/PageHeader.tsx
@@ -1,0 +1,29 @@
+import { FunctionalComponent } from "preact";
+import { ComponentChildren, JSX } from "preact";
+
+import clsx from "clsx";
+
+import { Eyebrow } from "./Eyebrow";
+
+type PageHeaderProps = {
+  eyebrow?: ComponentChildren;
+  title: ComponentChildren;
+  subline?: ComponentChildren;
+  className?: string;
+} & Omit<JSX.HTMLAttributes<HTMLDivElement>, "title">;
+
+export const PageHeader: FunctionalComponent<PageHeaderProps> = ({
+  eyebrow,
+  title,
+  subline,
+  className,
+  ...props
+}) => {
+  return (
+    <div className={clsx("flex flex-col gap-1", className)} {...props}>
+      {eyebrow ? <Eyebrow>{eyebrow}</Eyebrow> : null}
+      <h1 className="font-display text-d-xl leading-none text-text">{title}</h1>
+      {subline ? <p className="font-sans text-body text-muted mt-2">{subline}</p> : null}
+    </div>
+  );
+};

--- a/packages/frontend/src/components/ui/Pill.tsx
+++ b/packages/frontend/src/components/ui/Pill.tsx
@@ -1,0 +1,24 @@
+import clsx from "clsx";
+
+type PillProps = {
+  className?: string;
+  children?: React.ReactNode;
+};
+
+/**
+ * Generic small pill chip — mono, uppercase, hairline border.
+ * Composable: pass `className` to recolor (e.g. a yellow "New" badge)
+ * or otherwise override the defaults.
+ */
+export function Pill({ className, children }: PillProps) {
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center font-mono uppercase text-meta tracking-wider rounded-pill border-hair border-line px-2.5 py-1 text-text",
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}

--- a/packages/frontend/src/components/ui/ProgressBar.tsx
+++ b/packages/frontend/src/components/ui/ProgressBar.tsx
@@ -1,0 +1,37 @@
+import clsx from "clsx";
+
+export type ProgressBarStatus = "available" | "selling-fast" | "sold-out";
+
+export interface ProgressBarProps {
+  pct: number;
+  status: ProgressBarStatus;
+  className?: string;
+}
+
+const FILL_CLASS: Record<ProgressBarStatus, string> = {
+  available: "bg-success",
+  "selling-fast": "bg-warning",
+  "sold-out": "bg-danger",
+};
+
+export function ProgressBar({ pct, status, className }: ProgressBarProps) {
+  const clamped = Math.min(100, Math.max(0, pct));
+
+  return (
+    <div
+      className={clsx(
+        "w-full h-1.5 rounded-pill bg-track overflow-hidden",
+        className,
+      )}
+      role="progressbar"
+      aria-valuenow={clamped}
+      aria-valuemin={0}
+      aria-valuemax={100}
+    >
+      <div
+        className={clsx("h-full rounded-pill", FILL_CLASS[status])}
+        style={{ width: `${clamped}%` }}
+      />
+    </div>
+  );
+}

--- a/packages/frontend/src/components/ui/SegmentedToggle.tsx
+++ b/packages/frontend/src/components/ui/SegmentedToggle.tsx
@@ -1,0 +1,49 @@
+import clsx from "clsx";
+
+export interface SegmentedToggleOption<T extends string = string> {
+  label: string;
+  value: T;
+}
+
+export interface SegmentedToggleProps<T extends string = string> {
+  options: SegmentedToggleOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  className?: string;
+}
+
+export function SegmentedToggle<T extends string = string>({
+  options,
+  value,
+  onChange,
+  className,
+}: SegmentedToggleProps<T>) {
+  return (
+    <div
+      className={clsx(
+        "inline-flex items-center gap-1 border-hair border-line rounded-pill p-1 bg-surface",
+        className,
+      )}
+    >
+      {options.map((option) => {
+        const active = value === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => onChange(option.value)}
+            aria-pressed={active}
+            className={clsx(
+              "rounded-pill px-3 py-1 font-sans text-caption transition",
+              active
+                ? "bg-solid text-solid-fg"
+                : "text-text hover:bg-track",
+            )}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/ui/StatusPill.tsx
+++ b/packages/frontend/src/components/ui/StatusPill.tsx
@@ -1,0 +1,42 @@
+import clsx from "clsx";
+
+export type StatusPillStatus = "available" | "selling-fast" | "sold-out";
+
+type StatusPillProps = {
+  status?: StatusPillStatus;
+  className?: string;
+};
+
+const STATUS_CONFIG: Record<StatusPillStatus, { label: string; classes: string }> = {
+  available: {
+    label: "Available",
+    classes: "text-success bg-success-soft border-success",
+  },
+  "selling-fast": {
+    label: "Selling Fast",
+    classes: "text-warning bg-warning-soft border-warning",
+  },
+  "sold-out": {
+    label: "Sold Out",
+    classes: "text-danger bg-danger-soft border-danger",
+  },
+};
+
+/**
+ * Uppercase mono status chip colored by availability (theme-constant tokens).
+ */
+export function StatusPill({ status = "available", className }: StatusPillProps) {
+  const config = STATUS_CONFIG[status];
+
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center font-mono uppercase text-meta tracking-wider rounded-pill border-hair px-2 py-0.5",
+        config.classes,
+        className,
+      )}
+    >
+      {config.label}
+    </span>
+  );
+}

--- a/packages/frontend/src/components/ui/TicketCard.tsx
+++ b/packages/frontend/src/components/ui/TicketCard.tsx
@@ -1,0 +1,24 @@
+import clsx from "clsx";
+
+type TicketCardProps = {
+  className?: string;
+  children?: React.ReactNode;
+};
+
+/**
+ * Base surface card used as the ticket body. Thin, unopinionated wrapper —
+ * just the signature surface + hairline border + block shadow. Compose with
+ * TicketStub / CardHeader / CardBody etc. for richer layouts.
+ */
+export function TicketCard({ className, children }: TicketCardProps) {
+  return (
+    <div
+      className={clsx(
+        "bg-surface border-hair border-line rounded-panel shadow-block-md overflow-hidden",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/ui/TicketStub.tsx
+++ b/packages/frontend/src/components/ui/TicketStub.tsx
@@ -1,0 +1,28 @@
+import type { ComponentChildren } from "preact";
+import clsx from "clsx";
+
+type TicketStubProps = {
+  className?: string;
+  children?: ComponentChildren;
+};
+
+export function TicketStub({ className, children }: TicketStubProps) {
+  return (
+    <div
+      className={clsx(
+        "relative bg-bg border-l-2 border-dashed border-line p-6 md:p-8",
+        className,
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className="absolute -left-[7px] top-3 h-3.5 w-3.5 rounded-full bg-bg border-hair border-line"
+      />
+      <span
+        aria-hidden="true"
+        className="absolute -left-[7px] bottom-3 h-3.5 w-3.5 rounded-full bg-bg border-hair border-line"
+      />
+      {children}
+    </div>
+  );
+}

--- a/packages/frontend/src/hooks/useTheme.ts
+++ b/packages/frontend/src/hooks/useTheme.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "preact/hooks";
+
+export type Theme = "light" | "dark";
+
+const STORAGE_KEY = "cc-theme";
+
+function getInitialTheme(): Theme {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return "light";
+  }
+
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (stored === "light" || stored === "dark") {
+    return stored;
+  }
+
+  const domTheme = document.documentElement.dataset.theme;
+  if (domTheme === "light" || domTheme === "dark") {
+    return domTheme;
+  }
+
+  return "light";
+}
+
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>(() => getInitialTheme());
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+    document.documentElement.setAttribute("data-theme", theme);
+    // Sync on mount only; toggle() handles subsequent updates itself.
+    // eslint-disable-next-line preact-hooks/exhaustive-deps
+  }, []);
+
+  const toggle = () => {
+    setTheme((current) => {
+      const next: Theme = current === "light" ? "dark" : "light";
+
+      if (typeof document !== "undefined") {
+        document.documentElement.setAttribute("data-theme", next);
+      }
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(STORAGE_KEY, next);
+      }
+
+      return next;
+    });
+  };
+
+  return { theme, toggle };
+}

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -38,6 +38,7 @@ const SignOut = lazy(() => import("./pages/Auth/SignOut"));
 const Profile = lazy(() => import("./pages/Profile"));
 const Terms = lazy(() => import("./pages/Terms"));
 const Updates = lazy(() => import("./pages/Updates"));
+const Gallery = lazy(() => import("./pages/Gallery"));
 
 const onRouteChange = (url: string) => {
   console.log("root", url);
@@ -64,6 +65,7 @@ export function App() {
                 <Comic path="/comics/:id" />
                 <Terms path="/terms-privacy" />
                 <Updates path="/updates" />
+                <Gallery path="/gallery" />
                 <Profile path="/profile" />
                 <SignUp path="/sign-up" />
                 <SignIn path="/sign-in" />

--- a/packages/frontend/src/pages/Gallery/index.tsx
+++ b/packages/frontend/src/pages/Gallery/index.tsx
@@ -1,0 +1,288 @@
+import { useState } from "preact/hooks";
+import type { ComponentChildren } from "preact";
+
+import { Button } from "../../components/Button";
+import { Card, CardHeader, CardBody, CardFooter } from "../../components/Card";
+import { Input } from "../../components/Input";
+import { Link } from "../../components/Link";
+import { Checkbox } from "../../components/Checkbox";
+import { Spinner } from "../../components/Spinner";
+import { Perforation } from "../../components/Perforation";
+import { ThemeToggle } from "../../components/ThemeToggle";
+
+import { Eyebrow } from "../../components/ui/Eyebrow";
+import { PageHeader } from "../../components/ui/PageHeader";
+import { Pill } from "../../components/ui/Pill";
+import { StatusPill } from "../../components/ui/StatusPill";
+import { ProgressBar } from "../../components/ui/ProgressBar";
+import { SegmentedToggle } from "../../components/ui/SegmentedToggle";
+import { Avatar } from "../../components/ui/Avatar";
+import { FlameMeter } from "../../components/ui/FlameMeter";
+import { TicketStub } from "../../components/ui/TicketStub";
+import { TicketCard } from "../../components/ui/TicketCard";
+import { SWATCHES } from "../../utils/swatches";
+
+/**
+ * Component gallery / kitchen sink — renders every Wave 0B-0D primitive and
+ * ui-kit component in the "vintage marquee" style for visual review. Not a
+ * production route; a dev preview at /gallery. Flip the bottom-right toggle to
+ * check dark mode. Wrapped in a bg-bg surface so the intended page background
+ * shows even though the app's screens aren't re-skinned yet.
+ */
+
+function Section({
+  title,
+  note,
+  children,
+}: {
+  title: string;
+  note?: string;
+  children: ComponentChildren;
+}) {
+  return (
+    <section className="flex flex-col gap-4 border-hair border-line rounded-panel bg-surface p-6 shadow-block-md">
+      <div className="flex flex-col gap-1">
+        <Eyebrow>{title}</Eyebrow>
+        {note ? <p className="font-sans text-caption text-muted">{note}</p> : null}
+      </div>
+      <div className="flex flex-wrap items-start gap-4">{children}</div>
+    </section>
+  );
+}
+
+function Swatch({ bg, fg, i }: { bg: string; fg: string; i: number }) {
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <div
+        className="grid h-14 w-14 place-items-center rounded-panel border-hair border-line font-display text-lead"
+        style={{ background: bg, color: fg }}
+      >
+        {i + 1}
+      </div>
+      <span className="font-mono text-meta text-muted">{bg}</span>
+    </div>
+  );
+}
+
+export default function Gallery() {
+  const [mode, setMode] = useState<"relaxed" | "compact">("relaxed");
+  const [tab, setTab] = useState<"settings" | "profile">("settings");
+  const [alerts, setAlerts] = useState(true);
+  const [muted, setMuted] = useState(false);
+
+  return (
+    <div className="min-h-screen bg-bg text-text">
+      <ThemeToggle />
+
+      <div className="mx-auto flex max-w-5xl flex-col gap-8 px-6 py-10">
+        <PageHeader
+          eyebrow="Design System · Wave 0B–0D"
+          title="Component Gallery"
+          subline={
+            <>
+              Every re-skinned primitive and ui-kit component.{" "}
+              <span className="font-bold text-success">Toggle dark mode</span>{" "}
+              bottom-right to check token flips.
+            </>
+          }
+        />
+
+        {/* ---------- Chrome ---------- */}
+        <Section title="Chrome · Perforation" note="Ticket-edge strip rendered under the marquee header (already live at the top of this page).">
+          <div className="w-full overflow-hidden rounded-card border-hair border-line">
+            <Perforation />
+          </div>
+        </Section>
+
+        {/* ---------- Typography ---------- */}
+        <Section title="Typography · Eyebrow + PageHeader">
+          <div className="flex flex-col gap-4">
+            <Eyebrow>Sunday · June 28, 2026</Eyebrow>
+            <PageHeader
+              eyebrow="The Lineup"
+              title="Meet the Comics"
+              subline="Mono eyebrow → Bebas headline → muted subline."
+            />
+          </div>
+        </Section>
+
+        {/* ---------- Buttons ---------- */}
+        <Section title="Buttons" note="variant: solid | outline | reserve · size: xs → xl">
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-wrap items-center gap-3">
+              <Button variant="solid">Solid</Button>
+              <Button variant="outline">Outline</Button>
+              <Button variant="reserve">Reserve Tickets →</Button>
+              <Button disabled>Disabled</Button>
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <Button size="xs">xs</Button>
+              <Button size="sm">sm</Button>
+              <Button size="md">md</Button>
+              <Button size="lg">lg</Button>
+              <Button size="xl">xl</Button>
+            </div>
+          </div>
+        </Section>
+
+        {/* ---------- Pills / status ---------- */}
+        <Section title="Pills · Status · Progress">
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-wrap items-center gap-3">
+              <Pill>Generic</Pill>
+              <Pill className="border-brand bg-brand text-brand-fg">New</Pill>
+              <StatusPill status="available" />
+              <StatusPill status="selling-fast" />
+              <StatusPill status="sold-out" />
+            </div>
+            <div className="flex w-72 flex-col gap-3">
+              <ProgressBar pct={30} status="available" />
+              <ProgressBar pct={70} status="selling-fast" />
+              <ProgressBar pct={100} status="sold-out" />
+            </div>
+          </div>
+        </Section>
+
+        {/* ---------- Segmented toggles ---------- */}
+        <Section title="SegmentedToggle" note="Controlled — click to switch">
+          <div className="flex flex-wrap items-center gap-6">
+            <div className="flex flex-col gap-2">
+              <SegmentedToggle
+                options={[
+                  { label: "Relaxed", value: "relaxed" },
+                  { label: "Compact", value: "compact" },
+                ]}
+                value={mode}
+                onChange={setMode}
+              />
+              <span className="font-mono text-meta text-muted">mode: {mode}</span>
+            </div>
+            <div className="flex flex-col gap-2">
+              <SegmentedToggle
+                options={[
+                  { label: "Settings", value: "settings" },
+                  { label: "Profile", value: "profile" },
+                ]}
+                value={tab}
+                onChange={setTab}
+              />
+              <span className="font-mono text-meta text-muted">tab: {tab}</span>
+            </div>
+          </div>
+        </Section>
+
+        {/* ---------- Inputs / form ---------- */}
+        <Section title="Input · Checkbox · Link" note="Focus the input to see the 3px yellow offset glow">
+          <div className="flex w-full max-w-md flex-col gap-4">
+            <Input placeholder="Search by comic name…" />
+            <Checkbox
+              label="new-show-alerts"
+              displayLabel="New Show Alerts"
+              description="Email me when new shows are announced."
+              checked={alerts}
+              onChange={setAlerts}
+            />
+            <div className="flex items-center gap-4">
+              <Link href="#" variant="default">
+                Default link
+              </Link>
+              <Link href="#" variant="underline">
+                Create an account
+              </Link>
+            </div>
+          </div>
+        </Section>
+
+        {/* ---------- Cards ---------- */}
+        <Section title="Card · TicketCard · TicketStub">
+          <div className="grid w-full gap-4 md:grid-cols-2">
+            <Card>
+              <CardHeader>
+                <h3 className="font-sans text-lead font-extrabold text-text">Card Header</h3>
+              </CardHeader>
+              <CardBody>
+                <p className="font-sans text-body text-muted">
+                  Surface, hairline ink border, block shadow, divided sections.
+                </p>
+              </CardBody>
+              <CardFooter>
+                <Button size="sm" variant="reserve">
+                  Action →
+                </Button>
+              </CardFooter>
+            </Card>
+
+            <TicketCard>
+              <div className="grid grid-cols-[1fr_1fr]">
+                <div className="flex flex-col gap-2 p-6">
+                  <Eyebrow>Your Show</Eyebrow>
+                  <p className="font-display text-d-sm leading-none text-text">
+                    Tonight at the Cellar
+                  </p>
+                  <p className="font-sans text-caption text-muted">
+                    Left = TicketCard body.
+                  </p>
+                </div>
+                <TicketStub>
+                  <Eyebrow>Ticket Stub</Eyebrow>
+                  <p className="mt-2 font-sans text-caption text-muted">
+                    Dashed seam + punched notch circles.
+                  </p>
+                </TicketStub>
+              </div>
+            </TicketCard>
+          </div>
+        </Section>
+
+        {/* ---------- Avatars + swatches ---------- */}
+        <Section title="Avatar · FlameMeter" note="Avatar swatch is a deterministic hash of the name">
+          <div className="flex flex-col gap-5">
+            <div className="flex flex-wrap items-center gap-4">
+              <Avatar name="Dave Attell" />
+              <Avatar name="Nikki Glaser" size={56} />
+              <Avatar name="Colin Quinn" size={76} />
+              <Avatar name="Comedy Fan" size={100} />
+            </div>
+            <div className="flex items-center gap-6">
+              {[0, 1, 2, 3].map((lvl) => (
+                <div key={lvl} className="flex flex-col items-center gap-1">
+                  <FlameMeter level={lvl} />
+                  <span className="font-mono text-meta text-muted">lvl {lvl}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </Section>
+
+        {/* ---------- Avatar swatch palette ---------- */}
+        <Section title="Swatch palette" note="utils/swatches.ts — 6 theme-constant bg/fg pairs">
+          <div className="flex flex-wrap gap-4">
+            {SWATCHES.map((s, i) => (
+              <Swatch key={i} bg={s.bg} fg={s.fg} i={i} />
+            ))}
+          </div>
+        </Section>
+
+        {/* ---------- Spinner ---------- */}
+        <Section title="Spinner · notification pills">
+          <div className="flex flex-wrap items-center gap-6">
+            <Spinner size={5} />
+            <Spinner size={8} />
+            <Spinner size={10} />
+            <button
+              type="button"
+              onClick={() => setMuted((m) => !m)}
+              className={
+                muted
+                  ? "rounded-pill border-hair px-3 py-1 font-mono text-meta uppercase tracking-wider text-faint"
+                  : "rounded-pill border-hair border-success bg-success-soft px-3 py-1 font-mono text-meta uppercase tracking-wider text-success"
+              }
+            >
+              {muted ? "Muted" : "Enabled"}
+            </button>
+          </div>
+        </Section>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/utils/swatches.ts
+++ b/packages/frontend/src/utils/swatches.ts
@@ -1,0 +1,52 @@
+/**
+ * Avatar swatch rotation — "vintage marquee" palette.
+ *
+ * 6 bg/fg pairs (theme-constant — same in light and dark) used to color
+ * initials-based avatar placeholders (comics, users) throughout the app.
+ * See plan/README.md "Comic/avatar swatch rotation" and
+ * src/components/ui/CONTRACT.md.
+ */
+
+export const SWATCHES: { bg: string; fg: string }[] = [
+  { bg: "#F3C44C", fg: "#1A1714" },
+  { bg: "#E7E0CF", fg: "#1A1714" },
+  { bg: "#1A1714", fg: "#F3C44C" },
+  { bg: "#E9C9A0", fg: "#1A1714" },
+  { bg: "#D9CDB6", fg: "#1A1714" },
+  { bg: "#2B2722", fg: "#FBF6EC" },
+];
+
+/**
+ * Deterministically maps a name to one of the SWATCHES pairs by summing
+ * char codes and taking the result modulo the number of swatches. Falls
+ * back to the first swatch for an empty/undefined name.
+ */
+export function getSwatch(name: string): { bg: string; fg: string } {
+  if (!name) {
+    return SWATCHES[0];
+  }
+
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash += name.charCodeAt(i);
+  }
+
+  return SWATCHES[hash % SWATCHES.length];
+}
+
+/**
+ * Returns up to two uppercase initials from the first two
+ * whitespace-separated words of a name. Empty/undefined name -> "".
+ */
+export function getInitials(name: string): string {
+  if (!name) {
+    return "";
+  }
+
+  const words = name.trim().split(/\s+/).filter(Boolean);
+
+  return words
+    .slice(0, 2)
+    .map((word) => word[0]!.toUpperCase())
+    .join("");
+}


### PR DESCRIPTION
Re-skins the shared primitives in place to the vintage-marquee tokens (Button variants, Card, Input focus glow, Checkbox, Link underline variant, Spinner, marquee Header + Perforation) and adds the new ui kit — Eyebrow, PageHeader, Pill, StatusPill, ProgressBar, SegmentedToggle, Avatar, FlameMeter, TicketStub, TicketCard — plus `utils/swatches` and the theme runtime (`useTheme` hook + `ThemeToggle`). Every component uses only theme-aware token utilities so light/dark flips cleanly, and existing prop APIs are preserved (additive-only). Also adds a `/gallery` preview route that renders every component for visual review and dark-mode checking. Frontend builds clean (`vite build`).