### PR TITLE
Re-skin all screens to vintage marquee (Phase 1)

### DIFF
--- a/packages/frontend/src/components/Act.tsx
+++ b/packages/frontend/src/components/Act.tsx
@@ -1,9 +1,9 @@
 export const Act = ({ name, website, description, img }) => {
   return (
     <>
-      <div className="flex-col flex-none items-center justify-center">
+      <div className="flex-none flex-col items-center justify-center">
         <img
-          className="h-10 w-10 rounded-full bg-gray-50"
+          className="size-10 rounded-full border-hair border-line bg-track object-cover"
           src={img}
           alt={`Image of ${name}`}
         />
@@ -13,11 +13,11 @@ export const Act = ({ name, website, description, img }) => {
           href={website}
           target={"_blank"}
           rel="noopener noreferrer"
-          className="text-sm font-semibold leading-6 text-gray-900"
+          className="font-sans text-caption font-semibold text-text hover:underline"
         >
           {name}
         </a>
-        <p className="mt-1 text-xs leading-5 text-gray-500 capitalize">
+        <p className="mt-1 font-mono text-meta capitalize text-muted">
           {description}
         </p>
       </div>

--- a/packages/frontend/src/components/Availablity.tsx
+++ b/packages/frontend/src/components/Availablity.tsx
@@ -12,18 +12,18 @@ export const Availablity = ({
 }) => {
   let hoverText = "Seating is available";
   let Component = CheckIcon;
-  let color = "text-green-400";
+  let color = "text-success";
   let text = "Available";
 
   if (isNearingCapacity) {
     Component = ExclamationCircleIcon;
-    color = "text-yellow-400";
+    color = "text-warning";
     hoverText = "This show is almost sold out";
   }
 
   if (isEventOver || soldout) {
     Component = NoSymbolIcon;
-    color = "text-red-400";
+    color = "text-danger";
     text = "Evt Ovr.";
     hoverText = "This show is over";
     if (soldout) {

--- a/packages/frontend/src/components/Calendar.tsx
+++ b/packages/frontend/src/components/Calendar.tsx
@@ -126,39 +126,42 @@ export function Calendar({ value, onChange }) {
     onChange(date);
   };
 
+  const weekdayInitials = ["S", "M", "T", "W", "T", "F", "S"];
+
   return (
-    <>
-      <div className="flex items-center text-gray-900">
+    <div className="border-hair border-line rounded-panel bg-surface p-[1.125rem] shadow-block-md">
+      <div className="mb-3.5 flex items-center justify-between">
         <button
           type="button"
           onClick={handlePreviousMonth}
-          className="-m-1.5 flex flex-none items-center justify-center p-1.5 text-gray-400 hover:text-gray-500"
+          className="flex size-7 items-center justify-center rounded-full border-hair border-line text-text outline-none transition hover:bg-track focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
         >
           <span className="sr-only">Previous month</span>
-          <ChevronLeftIcon className="h-5 w-5" aria-hidden="true" />
+          <ChevronLeftIcon className="size-4" aria-hidden="true" />
         </button>
-        <div className="flex-auto text-sm font-semibold">
+        <span className="font-display text-d-sm tracking-cap text-text">
           {monthString} {selectedYear}
-        </div>
+        </span>
         <button
           type="button"
           onClick={handleNextMonth}
-          className="-m-1.5 flex flex-none items-center justify-center p-1.5 text-gray-400 hover:text-gray-500"
+          className="flex size-7 items-center justify-center rounded-full border-hair border-line text-text outline-none transition hover:bg-track focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
         >
           <span className="sr-only">Next month</span>
-          <ChevronRightIcon className="h-5 w-5" aria-hidden="true" />
+          <ChevronRightIcon className="size-4" aria-hidden="true" />
         </button>
       </div>
-      <div className="mt-6 grid grid-cols-7 text-xs leading-6 text-gray-500">
-        <div>S</div>
-        <div>M</div>
-        <div>T</div>
-        <div>W</div>
-        <div>T</div>
-        <div>F</div>
-        <div>S</div>
+      <div className="grid grid-cols-7">
+        {weekdayInitials.map((name, index) => (
+          <span
+            key={index}
+            className="text-center font-mono text-[11px] text-faint"
+          >
+            {name}
+          </span>
+        ))}
       </div>
-      <div className="isolate mt-2 grid grid-cols-7 gap-px rounded-lg bg-gray-200 text-sm shadow-sm ring-1 ring-gray-200">
+      <div className="mt-1 grid grid-cols-7">
         {days.map((day, dayIdx) => (
           <CalendarButton
             key={day.date}
@@ -169,6 +172,6 @@ export function Calendar({ value, onChange }) {
           />
         ))}
       </div>
-    </>
+    </div>
   );
 }

--- a/packages/frontend/src/components/CalendarButton.tsx
+++ b/packages/frontend/src/components/CalendarButton.tsx
@@ -21,47 +21,37 @@ function extractDay(date: string): string {
   return date.split("-").pop().replace(/^0/, "");
 }
 
-export function CalendarButton({
-  day,
-  dayIdx,
-  days,
-  onClick,
-}: CalendarButtonProps) {
+export function CalendarButton({ day, onClick }: CalendarButtonProps) {
+  const { isToday, isSelected, isCurrentMonth } = day;
+
   return (
     <button
-      key={day.date}
       type="button"
-      className={clsx(
-        "py-1.5 hover:bg-gray-100 focus:z-10",
-        day.isCurrentMonth ? "bg-white" : "bg-gray-50",
-        (day.isSelected || day.isToday) && "font-semibold",
-        day.isSelected && "text-white",
-        day.isSelected && day.isToday && "text-black",
-        !day.isSelected &&
-          day.isCurrentMonth &&
-          !day.isToday &&
-          "text-gray-900",
-        !day.isSelected &&
-          !day.isCurrentMonth &&
-          !day.isToday &&
-          "text-gray-400",
-        day.isToday && !day.isSelected && "text-primary",
-        dayIdx === 0 && "rounded-tl-lg",
-        dayIdx === 6 && "rounded-tr-lg",
-        dayIdx === days.length - 7 && "rounded-bl-lg",
-        dayIdx === days.length - 1 && "rounded-br-lg"
-      )}
       onClick={() => {
         onClick(day.date);
       }}
+      aria-pressed={isSelected}
+      className="group relative flex h-[2.375rem] items-center justify-center rounded-full outline-none focus:z-10 focus-visible:z-10 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
     >
+      <span
+        aria-hidden="true"
+        className={clsx(
+          "absolute size-8 rounded-full transition-colors",
+          isToday && "border-hair border-line bg-brand",
+          isSelected && !isToday && "bg-solid",
+          !isToday &&
+            !isSelected &&
+            "group-hover:bg-track group-focus-visible:bg-track"
+        )}
+      />
       <time
-        title={dayIdx + ""}
         dateTime={day.date}
         className={clsx(
-          "mx-auto flex h-7 w-7 items-center justify-center rounded-full",
-          day.isSelected && day.isToday && "bg-primary",
-          day.isSelected && !day.isToday && "bg-gray-900"
+          "relative font-sans text-[13px] font-semibold",
+          isToday && "text-brand-fg",
+          isSelected && !isToday && "text-solid-fg",
+          !isToday && !isSelected && isCurrentMonth && "text-text",
+          !isToday && !isSelected && !isCurrentMonth && "text-faint"
         )}
       >
         {extractDay(day.date)}

--- a/packages/frontend/src/components/Disclaimer.tsx
+++ b/packages/frontend/src/components/Disclaimer.tsx
@@ -1,74 +1,54 @@
-import {
-  InformationCircleIcon,
-  FaceSmileIcon,
-  ArrowPathRoundedSquareIcon,
-  ClockIcon,
-  PhoneXMarkIcon,
-} from "@heroicons/react/24/outline";
-
-const disclaimers = [
+const houseRules = [
   {
     title: "2 item minimum per person.",
     description: "Food or Drink or bottle of water.",
-    imageUrl:
-      "https://www.comedycellar.com/wp-content/uploads/2023/05/comedycellar_2drinkmin_icon_dark_60.svg",
-    icon: FaceSmileIcon,
   },
   {
     title: "Individual comedian appearance subject to change without notice.",
     description:
       "But! We often have great stars dropping in without notice, so we feel it kinda evens itself out. In any event, all our shows are great so we are confident you’ll enjoy yourself.",
-    imageUrl:
-      "https://www.comedycellar.com/wp-content/uploads/2023/05/comedycellar_lineup_change_icon_dark_60.svg",
-    icon: ArrowPathRoundedSquareIcon,
   },
   {
     title: "All of our shows are phone free!",
     description:
       "We ask all guests to place their phones and smart watches into the pouches we provide (you will of course maintain possession of them) for the duration of the show.",
-    imageUrl:
-      "https://www.comedycellar.com/wp-content/uploads/2023/05/comedycellar_nophones_icon_dark_60.svg",
-    icon: PhoneXMarkIcon,
   },
   {
     title:
       "AM shows (after midnight) are the LATE NIGHT shows of the day chosen.",
     description:
       "For example: the Saturday 12:15 AM show is technically Sunday morning but it is the still the Saturday late show.",
-    imageUrl:
-      "https://www.comedycellar.com/wp-content/uploads/2023/05/comedycellar_Showtime_icon_dark_60.svg",
-    icon: ClockIcon,
-  },
-  {
-    title: "Affiliation Disclaimer",
-    description:
-      "This site is not affiliated with the Comedy Cellar. Please visit comedycellar.com for the official website terms and conditions.",
-    imageUrl:
-      "https://www.comedycellar.com/wp-content/uploads/2023/05/comedycellar_Showtime_icon_dark_60.svg",
-    icon: InformationCircleIcon,
   },
 ];
 
+const finePrint =
+  "This site is not affiliated with the Comedy Cellar. Please visit comedycellar.com for the official website terms and conditions.";
+
 export const Disclaimer = () => {
   return (
-    <>
-      {disclaimers.map((disclaimer) => (
-        <div key={disclaimer.title} className="flex rounded-lg">
-          <div className="shrink-0">
-            <div className="flow-root">
-              {<disclaimer.icon className="h-6 w-6" />}
-            </div>
-          </div>
-          <div className="ml-5">
-            <h3 className="text-sm font-medium text-gray-900">
-              {disclaimer.title}
+    <div>
+      <p className="mb-3.5 font-mono text-meta uppercase tracking-wider text-faint">
+        House Rules
+      </p>
+
+      <div className="flex flex-col gap-3.5">
+        {houseRules.map((rule) => (
+          <div key={rule.title}>
+            <h3 className="font-sans text-caption font-extrabold text-text">
+              {rule.title}
             </h3>
-            <p className="mt-2 text-xs text-gray-500">
-              {disclaimer.description}
+            <p className="mt-0.5 font-sans text-meta leading-relaxed text-muted">
+              {rule.description}
             </p>
           </div>
-        </div>
-      ))}
-    </>
+        ))}
+      </div>
+
+      <div className="my-4 border-t border-track" />
+
+      <p className="font-mono text-meta leading-relaxed text-faint">
+        {finePrint}
+      </p>
+    </div>
   );
 };

--- a/packages/frontend/src/components/Event.tsx
+++ b/packages/frontend/src/components/Event.tsx
@@ -1,18 +1,17 @@
 import { useState } from "preact/hooks";
-import { format, isPast } from "date-fns";
+import clsx from "clsx";
 import {
-  CalendarIcon,
-  MapPinIcon,
   ChevronDownIcon,
   ChevronUpIcon,
-  UsersIcon,
   ArrowTopRightOnSquareIcon,
 } from "@heroicons/react/20/solid";
-import { Availablity } from "./Availablity";
+
 import { Link } from "./Link";
 import { Act } from "./Act";
+import { StatusPill } from "./ui/StatusPill";
+import { ProgressBar } from "./ui/ProgressBar";
 import { Show, LineUp } from "../types";
-import { WARNING_OCCUPANCY_RATE } from "../utils/constants";
+import { getShowView } from "../pages/Home/types";
 
 type EventItemProps = {
   show: Show;
@@ -23,146 +22,130 @@ type EventItemProps = {
 export function Event(props: EventItemProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const { isLineUpLoading } = props;
-  const {
-    showName,
-    description,
-    soldout,
-    roomName,
-    timestamp,
-    occupancyRate,
-    reservationUrl,
-    totalGuests,
-    max,
-  } = props.show;
+  const { description, timestamp, reservationUrl } = props.show;
   const { acts } = props.lineUp;
-  const dateTime = new Date(timestamp * 1000);
-  const dateTimeString = dateTime.toISOString();
-  const date = format(dateTime, "MMMM do");
-  const time = format(dateTime, "h:mm a");
-  const isEventOver = isPast(dateTime);
-  const reserverdSeats = totalGuests > max ? max : totalGuests;
+
+  const view = getShowView(props.show);
 
   return (
     <>
-      <div className="flex space-x-3 md:space-x-6">
-        <div className="hidden sm:flex flex-col items-center justify-center">
-          <Availablity
-            soldout={soldout}
-            isEventOver={isEventOver}
-            isNearingCapacity={
-              occupancyRate > WARNING_OCCUPANCY_RATE && occupancyRate < 1
-            }
-          />
-        </div>
-
-        <div className="flex-auto">
-          <div className="flex">
-            <h3 className="font-semibold text-gray-900" title={description}>
-              {showName}
-            </h3>
-          </div>
-          <dl className="mt-2 flex flex-col text-gray-500 xl:flex-row">
-            <div className="flex items-start space-x-2">
-              <dt className="mt-0.5">
-                <span className="sr-only">Date</span>
-                <CalendarIcon
-                  className="h-5 w-5 text-gray-400"
-                  aria-hidden="true"
-                />
-              </dt>
-              <dd>
-                <time dateTime={dateTimeString}>
-                  {date} at {time}
-                </time>
-              </dd>
-            </div>
-            <div className="flex items-start space-x-2 xl:ml-2 xl:mt-0 xl:border-l xl:border-gray-400 xl:border-opacity-50 xl:pl-2">
-              <dt className="mt-0.5">
-                <span className="sr-only">Location</span>
-                <MapPinIcon
-                  className="h-5 w-5 text-gray-400"
-                  aria-hidden="true"
-                />
-              </dt>
-              <dd>{roomName}</dd>
-            </div>
-            <div className="flex items-start space-x-2 xl:ml-2 xl:mt-0 xl:border-l xl:border-gray-400 xl:border-opacity-50 xl:pl-2">
-              <dt className="mt-0.5">
-                <span className="sr-only">Occupancy Rate</span>
-                <UsersIcon
-                  className="h-5 w-5 text-gray-400"
-                  aria-hidden="true"
-                />
-              </dt>
-              <dd>
-                {reserverdSeats}/{max}
-              </dd>
-            </div>
-            <div className="sm:hidden flex items-start xl:ml-2 xl:mt-0 xl:border-l xl:border-gray-400 xl:border-opacity-50 xl:pl-2">
-              <span className="sr-only">Availability</span>
-              <Availablity
-                soldout={soldout}
-                isEventOver={isEventOver}
-                isNearingCapacity={
-                  occupancyRate > WARNING_OCCUPANCY_RATE && occupancyRate < 1
-                }
-              />
-            </div>
-          </dl>
-
-          {!isEventOver && !soldout && (
-            <div className="mt-2">
-              <Link href={`/reservations/${timestamp}`}>Reserve Tickets</Link>
-            </div>
+      <article className="group flex overflow-hidden rounded-card border-hair border-line bg-surface shadow-block transition hover:-translate-x-px hover:-translate-y-px hover:shadow-block-lg">
+        {/* Time stub */}
+        <div
+          className={clsx(
+            "relative flex w-28 shrink-0 flex-col items-center justify-center border-r-2 border-dashed border-line",
+            view.closed ? "bg-stub" : "bg-brand"
           )}
-        </div>
-        <div className="mt-0.5 flex items-center">
-          {!isEventOver && !soldout && (
-            <Link
-              target={"_blank"}
-              rel="noreferrer noopener"
-              href={reservationUrl}
-            >
-              <ArrowTopRightOnSquareIcon
-                className="-ml-0.5 h-5 w-5"
-                aria-hidden="true"
-              />
-            </Link>
-          )}
-          <button
-            className="px-2 py-1 text-xs font-semibold text-gray-900 ring-gray-300 border-0"
-            disabled={isLineUpLoading}
-            onClick={() => setIsExpanded(!isExpanded)}
-          >
-            {isExpanded ? (
-              <ChevronUpIcon className="-ml-0.5 h-5 w-5" aria-hidden="true" />
-            ) : (
-              <ChevronDownIcon className="-ml-0.5 h-5 w-5" aria-hidden="true" />
+        >
+          <time
+            dateTime={view.dateTimeString}
+            className={clsx(
+              "font-display text-d-md leading-none",
+              view.closed ? "text-stub-ink" : "text-brand-fg"
             )}
-          </button>
+          >
+            {view.time}
+          </time>
+          <span
+            className={clsx(
+              "font-mono text-[11px] tracking-wide",
+              view.closed ? "text-stub-ink" : "text-brand-fg"
+            )}
+          >
+            {view.ampm}
+          </span>
+          {view.soldOut && (
+            <span className="absolute bottom-3 rotate-[-8deg] rounded-[3px] border-hair border-danger bg-surface px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-wider text-danger">
+              SOLD
+            </span>
+          )}
         </div>
-      </div>
+
+        {/* Body */}
+        <div className="min-w-0 flex-1 px-5 py-4">
+          <div className="flex items-start justify-between gap-3">
+            <h3
+              className="min-w-0 font-sans text-lead font-extrabold text-text"
+              title={description}
+            >
+              {view.title}
+            </h3>
+            <StatusPill status={view.status} className="shrink-0" />
+          </div>
+
+          <div className="mb-3 mt-2.5 flex items-center gap-2">
+            <p className="min-w-0 truncate font-mono text-meta text-muted">
+              {view.venue} <span className="text-faint">·</span> {view.capLabel}
+            </p>
+            <div className="ml-auto flex shrink-0 items-center gap-1.5">
+              {view.reservable && (
+                <Link
+                  href={reservationUrl}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  aria-label="Open reservation page in a new tab"
+                  className="grid size-8 place-items-center rounded-full border-hair border-line text-muted no-underline transition hover:bg-track hover:text-text hover:no-underline"
+                >
+                  <ArrowTopRightOnSquareIcon
+                    className="size-4"
+                    aria-hidden="true"
+                  />
+                </Link>
+              )}
+              <button
+                type="button"
+                disabled={isLineUpLoading}
+                aria-expanded={isExpanded}
+                aria-label={isExpanded ? "Hide lineup" : "Show lineup"}
+                onClick={() => setIsExpanded(!isExpanded)}
+                className="grid size-8 place-items-center rounded-full border-hair border-line text-muted outline-none transition hover:bg-track hover:text-text disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
+              >
+                {isExpanded ? (
+                  <ChevronUpIcon className="size-4" aria-hidden="true" />
+                ) : (
+                  <ChevronDownIcon className="size-4" aria-hidden="true" />
+                )}
+              </button>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-3.5">
+            <div className="flex-1">
+              <ProgressBar pct={view.pct} status={view.status} />
+            </div>
+            {view.reservable ? (
+              <Link
+                href={`/reservations/${timestamp}`}
+                className="inline-flex shrink-0 items-center rounded-pill bg-solid px-4 py-2 font-sans text-caption font-bold text-solid-fg no-underline transition hover:bg-brand hover:text-brand-fg hover:no-underline"
+              >
+                Reserve Tickets &rarr;
+              </Link>
+            ) : (
+              <span className="shrink-0 font-mono text-[11px] text-faint">
+                Reservations closed
+              </span>
+            )}
+          </div>
+        </div>
+      </article>
+
       {isExpanded && (
-        <div className="mt-4">
-          <ul role="list" className="divide-y divide-gray-100">
+        <div className="mt-2.5 rounded-card border-hair border-line bg-surface p-4 shadow-block-sm">
+          <ul role="list" className="divide-y divide-line">
             {acts.length > 0 ? (
               acts.map((act, index) => (
                 <li
                   key={index}
-                  className="flex gap-x-4 py-4 first:pt-0 last:pb-0 even:bg-gray-50"
+                  className="flex gap-x-4 py-3 first:pt-0 last:pb-0"
                 >
                   <Act {...act} />
                 </li>
               ))
             ) : (
-              <li className="flex gap-x-4 py-4 first:pt-0 last:pb-0 even:bg-gray-50">
-                <div className="flex-auto">
-                  <div className="flex">
-                    <h3 className="font-semibold text-gray-900">
-                      No acts found for this show
-                    </h3>
-                  </div>
-                </div>
+              <li className="py-1">
+                <h3 className="font-sans text-caption font-semibold text-text">
+                  No acts found for this show
+                </h3>
               </li>
             )}
           </ul>

--- a/packages/frontend/src/components/EventLoader.tsx
+++ b/packages/frontend/src/components/EventLoader.tsx
@@ -1,38 +1,17 @@
 export function EventLoader() {
   return (
-    <div class="animate-pulse grow flex space-x-4">
-      <div class="hidden sm:flex shrink-0 space-y-4 items-center">
-        <div class="grid grid-cols-1">
-          <div class="rounded-full bg-gray-300 size-8"></div>
-          <div class="mt-0.5 h-4 bg-gray-300 rounded-sm" />
+    <div className="flex animate-pulse overflow-hidden rounded-card border-hair border-line bg-surface shadow-block">
+      <div className="w-28 shrink-0 border-r-2 border-dashed border-line bg-track" />
+      <div className="min-w-0 flex-1 space-y-3 px-5 py-4">
+        <div className="flex items-center justify-between gap-3">
+          <div className="h-4 w-44 rounded bg-track" />
+          <div className="h-4 w-20 rounded-pill bg-track" />
         </div>
-      </div>
-
-      <div class="flex-1 space-y-4">
-        <div class="grid grid-cols-6 gap-4">
-          <div class="h-4 bg-gray-300	rounded-sm col-span-5 sm:col-span-4" />
+        <div className="h-3 w-32 rounded bg-track" />
+        <div className="flex items-center gap-3.5">
+          <div className="h-1.5 flex-1 rounded-pill bg-track" />
+          <div className="h-9 w-36 rounded-pill bg-track" />
         </div>
-
-        <div class="space-y-4">
-          <div class="grid grid-cols-7 gap-4 divide-x divide-gray-100">
-            <div class="h-4 bg-gray-300	rounded-sm col-span-4 xl:col-span-2" />
-            <div class="h-4 bg-gray-300 rounded-sm col-span-4 xl:col-span-2" />
-            <div class="h-4 bg-gray-300 rounded-sm col-span-4 xl:col-span-2" />
-            <div class="sm:hidden h-4 bg-gray-300 rounded-sm col-span-4 xl:col-span-2" />
-          </div>
-        </div>
-      </div>
-
-      <div className="mt-0.5 flex items-center">
-        <span
-          aria-disabled={true}
-          className="mr-2 rounded-sm bg-gray-300 px-2 py-1 text-xs font-semibold text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300"
-        >
-          <div className="-ml-0.5 h-5 w-5"></div>
-        </span>
-        <span className="rounded-sm bg-gray-300 px-2 py-1 text-xs font-semibold text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300">
-          <div className="-ml-0.5 size-5"></div>
-        </span>
       </div>
     </div>
   );

--- a/packages/frontend/src/components/Input.tsx
+++ b/packages/frontend/src/components/Input.tsx
@@ -2,7 +2,7 @@ import { JSX } from "preact";
 
 import clsx from "clsx";
 
-type InputProps = JSX.HTMLAttributes<HTMLInputElement>;
+type InputProps = JSX.IntrinsicElements["input"];
 
 export function Input({ className, ...props }: InputProps) {
   return (

--- a/packages/frontend/src/components/SearchInput.tsx
+++ b/packages/frontend/src/components/SearchInput.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "preact/hooks";
-import { MagnifyingGlassIcon, XMarkIcon } from "@heroicons/react/24/outline";
-import { ArrowPathIcon } from "@heroicons/react/24/solid";
+import clsx from "clsx";
+
+import { Spinner } from "./Spinner";
 
 interface SearchInputProps {
   placeholder?: string;
@@ -48,36 +49,43 @@ export function SearchInput({
   };
 
   return (
-    <div className={`relative ${className}`}>
-      <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-        <MagnifyingGlassIcon className="size-5 text-gray-400" />
-      </div>
+    <div
+      className={clsx(
+        "flex items-center gap-3 rounded-pill border-hair border-line bg-bg px-[1.125rem] py-3",
+        "focus-within:shadow-[3px_3px_0_var(--color-brand)]",
+        disabled && "opacity-60",
+        className,
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className="select-none font-mono text-caption leading-none text-muted"
+      >
+        ⌕
+      </span>
       <input
         type="text"
         value={inputValue}
         onInput={(e) => setInputValue((e.target as HTMLInputElement).value)}
         placeholder={placeholder}
         disabled={disabled}
-        className={`block w-full rounded-md border-0 bg-white py-1.5 px-10 text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6 ${
-          disabled ? "bg-gray-50 text-gray-500" : ""
-        }`}
+        aria-label={placeholder}
+        className="min-w-0 flex-1 border-none bg-transparent font-sans text-body text-text outline-none placeholder:text-placeholder disabled:cursor-not-allowed"
       />
 
       {/* Loading spinner */}
-      {loading && (
-        <div className="pointer-events-none absolute inset-y-0 right-8 flex items-center">
-          <ArrowPathIcon className="size-4 animate-spin text-gray-400" />
-        </div>
-      )}
+      {loading && <Spinner size={5} />}
 
       {/* Clear button */}
       {inputValue && !disabled && (
         <button
           type="button"
           onClick={handleClear}
-          className="absolute inset-y-0 right-0 flex items-center pr-3 hover:text-gray-600"
+          className="flex items-center leading-none text-faint hover:text-text"
         >
-          <XMarkIcon className="size-5 text-gray-400" />
+          <span aria-hidden="true" className="text-body">
+            ×
+          </span>
           <span className="sr-only">Clear search</span>
         </button>
       )}

--- a/packages/frontend/src/components/ui/ProgressBar.tsx
+++ b/packages/frontend/src/components/ui/ProgressBar.tsx
@@ -1,6 +1,10 @@
 import clsx from "clsx";
 
-export type ProgressBarStatus = "available" | "selling-fast" | "sold-out";
+export type ProgressBarStatus =
+  | "available"
+  | "selling-fast"
+  | "sold-out"
+  | "ended";
 
 export interface ProgressBarProps {
   pct: number;
@@ -12,6 +16,7 @@ const FILL_CLASS: Record<ProgressBarStatus, string> = {
   available: "bg-success",
   "selling-fast": "bg-warning",
   "sold-out": "bg-danger",
+  ended: "bg-stub-ink",
 };
 
 export function ProgressBar({ pct, status, className }: ProgressBarProps) {

--- a/packages/frontend/src/components/ui/StatusPill.tsx
+++ b/packages/frontend/src/components/ui/StatusPill.tsx
@@ -1,6 +1,10 @@
 import clsx from "clsx";
 
-export type StatusPillStatus = "available" | "selling-fast" | "sold-out";
+export type StatusPillStatus =
+  | "available"
+  | "selling-fast"
+  | "sold-out"
+  | "ended";
 
 type StatusPillProps = {
   status?: StatusPillStatus;
@@ -19,6 +23,10 @@ const STATUS_CONFIG: Record<StatusPillStatus, { label: string; classes: string }
   "sold-out": {
     label: "Sold Out",
     classes: "text-danger bg-danger-soft border-danger",
+  },
+  ended: {
+    label: "Show Ended",
+    classes: "text-stub-ink bg-stub border-hair",
   },
 };
 

--- a/packages/frontend/src/pages/Auth/PageWrapper.tsx
+++ b/packages/frontend/src/pages/Auth/PageWrapper.tsx
@@ -1,3 +1,74 @@
-export default function PageWrapper({ children }) {
-  return <div className="mt-10 flex justify-center">{children}</div>;
+import type { ComponentChildren } from "preact";
+
+import { Eyebrow } from "../../components/ui/Eyebrow";
+
+type PageWrapperProps = {
+  children: ComponentChildren;
+  /** Mono uppercase gold kicker above the heading. */
+  eyebrow?: ComponentChildren;
+  /** Bebas marquee heading (rendered at text-d-lg / ~46px). */
+  title?: ComponentChildren;
+  /** Muted supporting line under the heading. */
+  subline?: ComponentChildren;
+  /** Body line rendered below the card (e.g. the "Create an account" link). */
+  footer?: ComponentChildren;
+  /** Mono footnote below the card (e.g. "Secured by Clerk"). */
+  footnote?: ComponentChildren;
+};
+
+/**
+ * Centered "ticket booth" wrapper for the auth screens. When any of the chrome
+ * props are supplied it renders the marquee header, a bordered surface card that
+ * slots the auth widget, plus the footer link + footnote. With no chrome props it
+ * falls back to the original plain centered wrapper (still used by the Profile page).
+ */
+export default function PageWrapper({
+  children,
+  eyebrow,
+  title,
+  subline,
+  footer,
+  footnote,
+}: PageWrapperProps) {
+  const hasChrome = Boolean(eyebrow || title || subline || footer || footnote);
+
+  if (!hasChrome) {
+    return <div className="mt-10 flex justify-center">{children}</div>;
+  }
+
+  const hasHeader = Boolean(eyebrow || title || subline);
+
+  return (
+    <div className="flex min-h-[calc(100vh-180px)] flex-col items-center justify-center px-4 py-12">
+      <div className="w-full max-w-md">
+        {hasHeader ? (
+          <div className="mb-6 text-center">
+            {eyebrow ? <Eyebrow>{eyebrow}</Eyebrow> : null}
+            {title ? (
+              <h1 className="mt-2 font-display text-d-lg tracking-tightcap text-text">
+                {title}
+              </h1>
+            ) : null}
+            {subline ? (
+              <p className="mt-1.5 font-sans text-body text-muted">{subline}</p>
+            ) : null}
+          </div>
+        ) : null}
+
+        <div className="rounded-2xl border-hair border-line bg-surface px-7 pb-6 py-6 shadow-block-lg">
+          {children}
+        </div>
+
+        {footer ? (
+          <p className="mt-4 text-center font-sans text-body text-muted">{footer}</p>
+        ) : null}
+
+        {footnote ? (
+          <p className="mt-5 text-center font-mono text-meta tracking-wide text-faint">
+            {footnote}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
 }

--- a/packages/frontend/src/pages/Auth/SignIn.tsx
+++ b/packages/frontend/src/pages/Auth/SignIn.tsx
@@ -1,17 +1,33 @@
 import { useEffect, useRef } from "preact/hooks";
+
 import { clerk } from "../../utils/clerk";
+import { Link } from "../../components/Link";
 import PageWrapper from "./PageWrapper";
+import { authAppearance } from "./authAppearance";
 
 export default function SignIn() {
   const signInRef = useRef();
   useEffect(() => {
     clerk.load().then(() => {
-      clerk.mountSignIn(signInRef.current);
+      clerk.mountSignIn(signInRef.current, { appearance: authAppearance });
     });
   }, []);
 
   return (
-    <PageWrapper>
+    <PageWrapper
+      eyebrow="Members' Entrance"
+      title="Take Your Seat"
+      subline="Welcome back — sign in to manage your reservations."
+      footnote="Secured by Clerk"
+      footer={
+        <>
+          New to the Cellar?{" "}
+          <Link href="/sign-up" variant="underline" className="font-extrabold">
+            Create an account
+          </Link>
+        </>
+      }
+    >
       <div ref={signInRef} />
     </PageWrapper>
   );

--- a/packages/frontend/src/pages/Auth/SignUp.tsx
+++ b/packages/frontend/src/pages/Auth/SignUp.tsx
@@ -1,25 +1,33 @@
 import { useEffect, useRef } from "preact/hooks";
+
 import { clerk } from "../../utils/clerk";
+import { Link } from "../../components/Link";
 import PageWrapper from "./PageWrapper";
+import { authAppearance } from "./authAppearance";
 
 export default function SignUp() {
   const signUpRef = useRef();
   useEffect(() => {
-    clerk
-      .load({
-        appearance: {
-          elements: {
-            cardBox: "bg-black",
-          },
-        },
-      })
-      .then(() => {
-        clerk.mountSignUp(signUpRef.current);
-      });
+    clerk.load().then(() => {
+      clerk.mountSignUp(signUpRef.current, { appearance: authAppearance });
+    });
   }, []);
 
   return (
-    <PageWrapper>
+    <PageWrapper
+      eyebrow="New Members"
+      title="Join the Cellar"
+      subline="Create an account to book and manage your reservations."
+      footnote="Secured by Clerk"
+      footer={
+        <>
+          Already have a seat?{" "}
+          <Link href="/sign-in" variant="underline" className="font-extrabold">
+            Sign in
+          </Link>
+        </>
+      }
+    >
       <div ref={signUpRef} />
     </PageWrapper>
   );

--- a/packages/frontend/src/pages/Auth/authAppearance.ts
+++ b/packages/frontend/src/pages/Auth/authAppearance.ts
@@ -1,0 +1,36 @@
+/**
+ * Clerk auth widget theming for the "vintage marquee" system.
+ * Shared between SignIn and SignUp pages.
+ *
+ * Colors reference theme.css runtime CSS vars so they flip automatically in
+ * dark mode. Card chrome (border/shadow/padding) is stripped so the widget
+ * blends into the PageWrapper surface, and Clerk's header/footer are hidden
+ * in favor of the marquee header + "Secured by Clerk" footnote.
+ */
+export const authAppearance = {
+  variables: {
+    colorPrimary: "var(--solid)",
+    colorPrimaryForeground: "var(--on-solid)",
+    colorBackground: "var(--surface)",
+    colorForeground: "var(--text)",
+    colorMutedForeground: "var(--muted)",
+    colorInput: "var(--bg)",
+    colorInputForeground: "var(--text)",
+    colorBorder: "var(--line)",
+    colorRing: "#F3C44C",
+    borderRadius: "9px",
+    fontFamily: "Archivo, system-ui, sans-serif",
+  },
+  elements: {
+    rootBox: "w-full",
+    cardBox: "w-full border-none! bg-transparent! p-0! shadow-none!",
+    card: "border-none! bg-transparent! p-0! shadow-none!",
+    header: "hidden",
+    footer: "hidden",
+    socialButtonsBlockButton:
+      "border-hair border-line rounded-field bg-surface hover:bg-track",
+    formButtonPrimary: "rounded-pill bg-solid hover:bg-solid-hover",
+    dividerLine: "bg-line",
+    dividerText: "text-muted font-mono text-meta",
+  },
+};

--- a/packages/frontend/src/pages/Comic/AlongsideComics.tsx
+++ b/packages/frontend/src/pages/Comic/AlongsideComics.tsx
@@ -3,35 +3,39 @@ import { Comic as ComicType } from "../../types";
 const comics = [];
 export function AlongsideComics({ comicId }: { comicId: string }) {
   return (
-    <div className="mx-auto mt-4 max-w-5xl p-4 sm:px-6 lg:px-8">
-      <h2 className="text-sm font-medium text-gray-500">See alongside:</h2>
-      <div className="mt-1 grid grid-cols-1 gap-4 sm:grid-cols-2">
+    <div className="mt-8">
+      <h2 className="mb-3 font-mono uppercase text-label tracking-wider text-faint">
+        See alongside:
+      </h2>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         {comics.length ? (
           comics.map((comic) => (
             <div
               key={comic.externalId}
-              className="relative flex items-center space-x-3 rounded-lg border border-gray-300 bg-white px-6 py-5 shadow-xs focus-within:ring-2 focus-within:ring-pink-500 focus-within:ring-offset-2 hover:border-gray-400"
+              className="relative flex items-center gap-x-3 rounded-card border-hair border-line bg-surface px-6 py-5 shadow-block-sm transition focus-within:ring-2 focus-within:ring-brand focus-within:ring-offset-2 hover:-translate-x-px hover:-translate-y-px hover:shadow-block"
             >
               <div className="shrink-0">
                 <Img
                   alt=""
                   src={comic.img}
-                  className="h-10 w-10 rounded-full"
+                  className="size-10 rounded-pill border-hair border-line"
                 />
               </div>
               <div className="min-w-0 flex-1">
                 <a href="#" className="focus:outline-hidden">
                   <span aria-hidden="true" className="absolute inset-0" />
-                  <p className="text-sm font-medium text-gray-900">
+                  <p className="font-sans text-body font-bold text-text">
                     {comic.name}
                   </p>
-                  {/* <p className="truncate text-sm text-gray-500">{comic.role}</p> */}
+                  {/* <p className="truncate text-sm text-muted">{comic.role}</p> */}
                 </a>
               </div>
             </div>
           ))
         ) : (
-          <span>Doesn't have any upcoming shows</span>
+          <span className="font-mono text-caption text-muted">
+            Doesn't have any upcoming shows
+          </span>
         )}
       </div>
     </div>

--- a/packages/frontend/src/pages/Comic/ComicBannerImage.tsx
+++ b/packages/frontend/src/pages/Comic/ComicBannerImage.tsx
@@ -1,13 +1,30 @@
-const coverImg = [
-  "/cellar.webp",
-  "/ComedyCellar_MacDougalstNYC.jpg",
-  "/TheStairs_empty.jpg",
-];
+import clsx from "clsx";
 
-function getRandomInt(max) {
-  return Math.floor(Math.random() * max);
-}
-
-export default function ComicBannerImage(props) {
-  return <img src={coverImg[getRandomInt(3)]} {...props} />;
+/**
+ * Cellar stage-photo placeholder banner. Per the vintage-marquee design this is
+ * an intentional placeholder (diagonal cream-on-ink stripes), not a real photo.
+ * The stripe colors are theme-independent literals — they read as a dark stage
+ * wall in both light and dark mode — so they stay inline hex.
+ */
+export default function ComicBannerImage({ className }: { className?: string }) {
+  return (
+    <div
+      className={clsx(
+        "relative flex h-[14.375rem] items-center justify-center",
+        className,
+      )}
+      style={{
+        background: "#231F1A",
+        backgroundImage:
+          "repeating-linear-gradient(135deg, #2A251F 0 14px, #211D18 14px 28px)",
+      }}
+    >
+      <span
+        className="font-mono uppercase text-caption text-[#6F665A]"
+        style={{ letterSpacing: "0.16em" }}
+      >
+        Cellar stage photo
+      </span>
+    </div>
+  );
 }

--- a/packages/frontend/src/pages/Comic/ComicNotification.tsx
+++ b/packages/frontend/src/pages/Comic/ComicNotification.tsx
@@ -71,7 +71,8 @@ export default function ComicNotification() {
   return (
     <Button
       type="button"
-      className="inline-flex gap-x-1.5"
+      variant="outline"
+      className="inline-flex items-center gap-x-1.5 px-5 py-2.5 text-sm font-bold shadow-block-sm"
       onClick={handleToggle}
     >
       {mutation.isPending ? (
@@ -81,18 +82,12 @@ export default function ComicNotification() {
         </>
       ) : isEnabled ? (
         <>
-          <BellIconSolid
-            aria-hidden="true"
-            className="-ml-0.5 h-5 w-5 text-gray-400"
-          />
+          <BellIconSolid aria-hidden="true" className="-ml-0.5 size-5" />
           Subscribed
         </>
       ) : (
         <>
-          <BellIcon
-            aria-hidden="true"
-            className="-ml-0.5 h-5 w-5 text-gray-400"
-          />
+          <BellIcon aria-hidden="true" className="-ml-0.5 size-5" />
           Subscribe
         </>
       )}

--- a/packages/frontend/src/pages/Comic/UpcomingShows.tsx
+++ b/packages/frontend/src/pages/Comic/UpcomingShows.tsx
@@ -1,6 +1,5 @@
 import { Comic as ComicType, ListApiRes, ShowDb } from "../../types";
 
-import { Spinner } from "../../components/Spinner";
 import { fetchShowsNew } from "../../utils/api";
 import { useMemo } from "preact/hooks";
 import { useQuery } from "@tanstack/react-query";
@@ -69,66 +68,81 @@ export function UpcomingShows({ comicId }: { comicId: string }) {
   }, [data]);
 
   return (
-    <div className="mx-auto mt-4 max-w-5xl py-4 sm:px-6 lg:px-8 space-y-2">
-      <h2 className="text-sm font-medium">Upcoming shows:</h2>
+    <div className="mt-8">
+      <h2 className="mb-4 font-display text-d-sm tracking-cap text-text">
+        Upcoming Shows
+      </h2>
 
       {isFetching ? (
-        <div className="mt-1 grid grid-cols-1 gap-4 sm:grid-cols-2">
-          {new Array(4).fill(0).map((i) => (
-            <ShowItemSkeleton />
+        <div className="flex flex-col gap-3">
+          {new Array(4).fill(0).map((_, i) => (
+            <ShowItemSkeleton key={i} />
           ))}
         </div>
       ) : shows.length ? (
-        <ol className=" space-y-3">
-          {shows.map(({ date, shows }) => (
-            <li className="">
-              <h3 className="text-sm font-medium text-gray-500 underline">
-                {date}
-              </h3>
-              <div className="mt-2 grid grid-cols-1 gap-4 sm:grid-cols-2">
-                {shows.map((show) => (
-                  <ShowItem show={show} />
-                ))}
-              </div>
-            </li>
-          ))}
+        <ol className="flex flex-col gap-3">
+          {shows.map(({ shows }) =>
+            shows.map((show) => <ShowItem key={show.externalId} show={show} />)
+          )}
         </ol>
       ) : (
-        // TODO: fix UI on this
-        <span>No upcoming shows</span>
+        <p className="font-mono text-caption text-muted">No upcoming shows</p>
       )}
     </div>
   );
 }
 
 function ShowItem({ show }: { show: ShowDb }) {
+  const dt = new Date(show.timestamp * 1000);
+  const day = dt.toLocaleDateString("en-US", { day: "2-digit" });
+  const mon = dt
+    .toLocaleDateString("en-US", { month: "short" })
+    .toUpperCase();
+  const meta = `${dt.toLocaleDateString("en-US", {
+    weekday: "short",
+  })} · ${dt.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })} · ${dt.toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+  })}`;
+
   return (
-    <div
-      key={show.externalId}
-      className="relative flex items-center space-x-3 rounded-lg border border-gray-300 bg-white px-6 py-5 shadow-xs focus-within:ring-2 focus-within:ring-pink-500 focus-within:ring-offset-2 hover:border-gray-400"
-    >
-      <div className="min-w-0 flex-1">
-        <a
-          href={`/reservations/${show.timestamp}`}
-          className="focus:outline-hidden"
-        >
-          <span aria-hidden="true" className="absolute inset-0" />
-          <p className="text-sm font-medium text-gray-900">
+    <li className="flex items-stretch overflow-hidden rounded-card border-hair border-line bg-bg shadow-block transition hover:-translate-x-px hover:-translate-y-px hover:shadow-block-lg">
+      <div className="flex w-24 shrink-0 flex-col items-center justify-center border-r-2 border-dashed border-line bg-brand py-3.5">
+        <span className="font-display text-d-md leading-none text-brand-fg">
+          {day}
+        </span>
+        <span className="font-mono text-meta tracking-wide text-brand-fg">
+          {mon}
+        </span>
+      </div>
+      <div className="flex flex-1 items-center justify-between gap-4 px-5 py-3.5">
+        <div className="min-w-0">
+          <p className="font-sans text-[17px] font-extrabold text-text">
             {show.description}
           </p>
-          {/* TODO: Add more information about show here */}
-          {/* <p className="truncate text-sm text-gray-500">{comic.role}</p> */}
+          <p className="mt-0.5 font-mono text-caption text-muted">{meta}</p>
+        </div>
+        <a
+          href={`/reservations/${show.timestamp}`}
+          className="shrink-0 rounded-pill bg-solid px-4 py-2 font-sans text-caption font-bold text-solid-fg transition hover:bg-brand hover:text-brand-fg"
+        >
+          Reserve →
         </a>
       </div>
-    </div>
+    </li>
   );
 }
 
 function ShowItemSkeleton() {
   return (
-    <div className="animate-pulse  relative flex items-center space-x-3 rounded-lg border border-gray-300 bg-white px-6 py-5 shadow-xs focus-within:ring-2 focus-within:ring-pink-500 focus-within:ring-offset-2 hover:border-gray-400">
-      <div className="min-w-0 flex-1">
-        <div class="h-4 bg-gray-300	rounded-sm col-span-4 xl:col-span-2" />
+    <div className="flex animate-pulse items-stretch overflow-hidden rounded-card border-hair border-line bg-bg shadow-block">
+      <div className="w-24 shrink-0 border-r-2 border-dashed border-line bg-track" />
+      <div className="flex flex-1 items-center px-5 py-3.5">
+        <div className="h-4 w-2/3 rounded-field bg-track" />
       </div>
     </div>
   );

--- a/packages/frontend/src/pages/Comic/index.tsx
+++ b/packages/frontend/src/pages/Comic/index.tsx
@@ -2,8 +2,8 @@ import { AlongsideComics } from "./AlongsideComics";
 import ComicBannerImage from "./ComicBannerImage";
 import ComicNotification from "./ComicNotification";
 import { Comic as ComicType } from "../../types";
-import { GlobeAltIcon } from "@heroicons/react/20/solid";
-import { Img } from "../../components/Image";
+import { Avatar } from "../../components/ui/Avatar";
+import { Eyebrow } from "../../components/ui/Eyebrow";
 import { Link } from "../../components/Link";
 import { PageLoader } from "../../components/PageLoader";
 import { UpcomingShows } from "./UpcomingShows";
@@ -33,77 +33,64 @@ export default function Comic() {
   }
 
   return (
-    <div className="min-h-full flex flex-1 rounded-lg ring-1 ring-gray-200">
-      <div className="flex-1 pb-8">
-        <div>
-          <ComicBannerImage
-            className="h-32 w-full object-cover rounded-t-lg lg:h-48"
-            alt=""
-          />
-          <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-            <div className="-mt-12 sm:-mt-16 sm:flex sm:items-end sm:space-x-5">
-              <div className="flex">
-                <Img
-                  alt=""
-                  src={comic.data.img}
-                  className="h-24 w-24 rounded-full ring-4 ring-white sm:h-32 sm:w-32"
-                />
-              </div>
-              <div className="mt-6 sm:flex sm:min-w-0 sm:flex-1 sm:items-center sm:justify-end sm:space-x-6 sm:pb-1">
-                <div className="mt-6 min-w-0 flex-1 sm:hidden 2xl:block">
-                  <h1 className="truncate text-2xl font-bold text-gray-900">
-                    {comic.data.name}
-                  </h1>
-                </div>
-                <div className="mt-6 flex flex-col justify-stretch space-y-3 sm:flex-row sm:space-x-4 sm:space-y-0">
-                  {user && <ComicNotification />}
-                  {comic.data.website && (
-                    <Link
-                      href={comic.data.website}
-                      target={"_blank"}
-                      className="inline-flex justify-center gap-x-1.5 rounded-md bg-white px-3 py-2 text-sm font-semibold hover:no-underline text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
-                    >
-                      <GlobeAltIcon
-                        aria-hidden="true"
-                        className="-ml-0.5 h-5 w-5 text-gray-400"
-                      />
-                      Website
-                    </Link>
-                  )}
-                </div>
+    <div className="mx-auto max-w-6xl px-6 pt-8 pb-16 sm:px-10">
+      <Link
+        href="/comics"
+        className="mb-4 inline-block font-mono uppercase text-label tracking-wider text-muted hover:text-text hover:no-underline"
+      >
+        ‹ All comics
+      </Link>
+
+      {/* Profile card */}
+      <div className="overflow-hidden rounded-2xl border-hair border-line bg-surface shadow-block-lg">
+        <ComicBannerImage />
+
+        <div className="relative px-6 pb-8 sm:px-10">
+          {/* Identity row — pulled up over the banner */}
+          <div className="-mt-[4.125rem] flex items-end justify-between gap-5">
+            <div className="flex items-end gap-6">
+              <Avatar
+                name={comic.data.name}
+                size={132}
+                className="border-4 shadow-block"
+              />
+              <div className="pb-2">
+                <Eyebrow className="mb-1">Headliner</Eyebrow>
+                <h1 className="m-0 font-display text-d-lg tracking-tightcap text-text">
+                  {comic.data.name}
+                </h1>
               </div>
             </div>
-            <div className="mt-6 hidden min-w-0 flex-1 sm:block 2xl:hidden">
-              <h1 className="truncate text-2xl font-bold text-gray-900">
-                {comic.data.name}
-              </h1>
+
+            <div className="mb-2.5 flex shrink-0 items-center gap-3">
+              {user && <ComicNotification />}
+              {comic.data.website && (
+                <Link
+                  href={comic.data.website}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1.5 rounded-pill border-hair border-line bg-surface px-5 py-2.5 font-sans text-sm font-bold text-text shadow-block-sm transition hover:bg-brand hover:text-brand-fg hover:no-underline"
+                >
+                  Website ↗
+                </Link>
+              )}
             </div>
           </div>
+
+          {/* About */}
+          <div className="mt-8 max-w-[680px]">
+            <p className="mb-2.5 font-mono uppercase text-label tracking-wider text-faint">
+              About
+            </p>
+            <p className="m-0 font-sans text-[17px] leading-[1.65] text-text">
+              {comic.data.description}
+            </p>
+          </div>
+
+          <UpcomingShows comicId={comicId} />
+
+          {/* <AlongsideComics comicId={comicId} /> */}
         </div>
-
-        {/* Description list */}
-        <div className="mx-auto mt-6 max-w-5xl px-4 sm:px-6 lg:px-8">
-          <dl className="grid grid-cols-1 gap-x-4 gap-y-8 sm:grid-cols-2">
-            {/* {Object.keys(profile.fields).map((field) => (
-                <div key={field} className="sm:col-span-1">
-                  <dt className="text-sm font-medium text-gray-500">{field}</dt>
-                  <dd className="mt-1 text-sm text-gray-900">
-                    {profile.fields[field]}
-                  </dd>
-                </div>
-              ))} */}
-            <div className="sm:col-span-2">
-              <dt className="text-sm font-medium text-gray-500">About</dt>
-              <dd className="mt-1 max-w-prose space-y-5 text-sm text-gray-900">
-                {comic.data.description}
-              </dd>
-            </div>
-          </dl>
-        </div>
-
-        <UpcomingShows comicId={comicId} />
-
-        {/* <AlongsideComics comicId={comicId} /> */}
       </div>
     </div>
   );

--- a/packages/frontend/src/pages/Comics/ComicItem.tsx
+++ b/packages/frontend/src/pages/Comics/ComicItem.tsx
@@ -1,43 +1,49 @@
 import { Comic } from "../../types";
-import { Img } from "../../components/Image";
-import { LinkIcon } from "@heroicons/react/24/outline";
 import { ShowCount } from "./ShowCount";
+import { getInitials, getSwatch } from "../../utils/swatches";
 
 export function ComicItem({ comic }: { comic: Comic }) {
+  const { bg, fg } = getSwatch(comic.name);
+  const initials = getInitials(comic.name);
+
   return (
-    <li
-      key={comic.externalId}
-      className="flex-col grow rounded-lg ring-1 ring-gray-200 shadow-sm transition-shadow duration-300 hover:shadow-md"
-    >
-      <a href={`/comics/${comic.externalId}`} className={"grow"}>
-        <Img
-          alt={`${comic.name}'s picture`}
-          loading={"lazy"}
-          src={comic.img}
-          className="aspect-3/2 w-full rounded-lg object-cover"
-        />
-        <div className="flex-col grow justify-between p-4">
-          <div className="flex items-center space-x-2">
-            <h3 className="text-lg font-semibold leading-8 tracking-tight text-gray-900">
-              {comic.name}
-            </h3>
+    <li key={comic.externalId} className="list-none">
+      <a
+        href={`/comics/${comic.externalId}`}
+        className="block overflow-hidden rounded-card border-hair border-line bg-surface shadow-block transition-all duration-150 hover:-translate-x-px hover:-translate-y-px hover:shadow-block-lg focus:outline-none focus-visible:-translate-x-px focus-visible:-translate-y-px focus-visible:shadow-block-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
+      >
+        {/* Photo placeholder — swatch bg + centered Bebas initials */}
+        <div
+          className="relative flex h-[170px] items-center justify-center border-b-[1.5px] border-line"
+          style={{ backgroundColor: bg }}
+          role="img"
+          aria-label={`${comic.name}'s photo`}
+        >
+          <span
+            className="font-display text-[62px] leading-none tracking-[0.04em]"
+            style={{ color: fg }}
+          >
+            {initials}
+          </span>
+          <span
+            className="absolute bottom-2 right-2.5 font-mono text-[8px] uppercase tracking-wider"
+            style={{ color: fg, opacity: 0.55 }}
+          >
+            PHOTO
+          </span>
+        </div>
+
+        {/* Body */}
+        <div className="px-4 pb-4 pt-[14px]">
+          <h3 className="mb-[7px] font-sans text-[16px] font-extrabold text-text">
+            {comic.name}
+          </h3>
+          <div className="mb-[9px]">
             <ShowCount showCount={comic.showCount ?? 0} />
           </div>
-          <p className="text-base leading-7 text-gray-600 line-clamp-4">
+          <p className="line-clamp-3 font-sans text-caption leading-[1.5] text-muted">
             {comic.description}
           </p>
-          <ul role="list" className="mt-6 flex gap-x-6">
-            <li>
-              <a
-                href={comic.website}
-                target="_blank"
-                className="text-gray-400 hover:text-gray-500"
-              >
-                <span className="sr-only">Website</span>
-                <LinkIcon aria-hidden="true" className="h-5 w-5" />
-              </a>
-            </li>
-          </ul>
         </div>
       </a>
     </li>
@@ -46,21 +52,17 @@ export function ComicItem({ comic }: { comic: Comic }) {
 
 export function ComicItemSkeleton() {
   return (
-    <li className="animate-pulse flex flex-col grow rounded-lg ring-1 ring-gray-200 shadow-sm transition-shadow duration-300 hover:shadow-md">
-      <div className="flex-1 flex flex-col">
-        <div className="aspect-3/2 w-full rounded-lg bg-gray-300" />
-        <div className="flex flex-col flex-1 justify-between p-4 space-y-4">
-          <div className="h-6 bg-gray-300 rounded-sm w-3/4" />
-          <div className="space-y-2">
-            <div className="h-4 bg-gray-300 rounded-sm w-full" />
-            <div className="h-4 bg-gray-300 rounded-sm w-5/6" />
-            <div className="h-4 bg-gray-300 rounded-sm w-4/6" />
+    <li className="list-none animate-pulse">
+      <div className="block overflow-hidden rounded-card border-hair border-line bg-surface shadow-block">
+        <div className="h-[170px] border-b-[1.5px] border-line bg-track" />
+        <div className="flex flex-col gap-3 px-4 pb-4 pt-[14px]">
+          <div className="h-4 w-3/4 rounded-field bg-track" />
+          <div className="h-3 w-1/2 rounded-field bg-track" />
+          <div className="flex flex-col gap-2">
+            <div className="h-3 w-full rounded-field bg-track" />
+            <div className="h-3 w-5/6 rounded-field bg-track" />
+            <div className="h-3 w-4/6 rounded-field bg-track" />
           </div>
-          <ul role="list" className="mt-6 flex gap-x-6">
-            <li>
-              <div className="h-5 w-5 bg-gray-300 rounded-full" />
-            </li>
-          </ul>
         </div>
       </div>
     </li>

--- a/packages/frontend/src/pages/Comics/ComicItem.tsx
+++ b/packages/frontend/src/pages/Comics/ComicItem.tsx
@@ -14,13 +14,13 @@ export function ComicItem({ comic }: { comic: Comic }) {
       >
         {/* Photo placeholder — swatch bg + centered Bebas initials */}
         <div
-          className="relative flex h-[170px] items-center justify-center border-b-[1.5px] border-line"
+          className="relative flex h-44 items-center justify-center border-b-2 border-line"
           style={{ backgroundColor: bg }}
           role="img"
           aria-label={`${comic.name}'s photo`}
         >
           <span
-            className="font-display text-[62px] leading-none tracking-[0.04em]"
+            className="font-display text-8xl leading-none tracking-[0.04em]"
             style={{ color: fg }}
           >
             {initials}
@@ -34,14 +34,14 @@ export function ComicItem({ comic }: { comic: Comic }) {
         </div>
 
         {/* Body */}
-        <div className="px-4 pb-4 pt-[14px]">
-          <h3 className="mb-[7px] font-sans text-[16px] font-extrabold text-text">
+        <div className="px-4 pb-4 pt-4">
+          <h3 className="mb-2 font-sans text-base font-extrabold text-text">
             {comic.name}
           </h3>
-          <div className="mb-[9px]">
+          <div className="mb-3">
             <ShowCount showCount={comic.showCount ?? 0} />
           </div>
-          <p className="line-clamp-3 font-sans text-caption leading-[1.5] text-muted">
+          <p className="line-clamp-3 font-sans text-caption leading-relaxed text-muted">
             {comic.description}
           </p>
         </div>

--- a/packages/frontend/src/pages/Comics/ShowCount.tsx
+++ b/packages/frontend/src/pages/Comics/ShowCount.tsx
@@ -1,55 +1,64 @@
-import { FireIcon } from "@heroicons/react/20/solid";
+import clsx from "clsx";
 
-export function ActivityIcon() {
-  return <FireIcon className="h-5 w-5 fill-yellow-400 stroke-orange-300" />;
+import { FlameMeter } from "../../components/ui/FlameMeter";
+
+/**
+ * Maps an upcoming-show count to the design's heat tier (0–3):
+ * 0 shows → 0 · 1–4 → 1 · 5–8 → 2 · 9+ → 3.
+ */
+export function heatTier(showCount: number): number {
+  if (showCount <= 0) return 0;
+  if (showCount <= 4) return 1;
+  if (showCount <= 8) return 2;
+  return 3;
 }
 
+/**
+ * Per-comic heat indicator: a FlameMeter plus an "{n} upcoming" / "No shows"
+ * label.
+ */
 export function ShowCount({ showCount }: { showCount: number }) {
-  if (showCount > 0) {
-    const iconCount = showCount > 8 ? 3 : showCount >= 5 ? 2 : 1;
-    return (
-      <div className="flex items-center">
-        {[...Array(iconCount)].map((_, index) => (
-          <ActivityIcon key={index} />
-        ))}
-      </div>
-    );
-  }
+  const count = showCount ?? 0;
+  const hasShows = count > 0;
 
   return (
-    <div className="">
-      <FireIcon className="h-5 w-5 fill-neutral-400" />
+    <div className="flex items-center gap-[7px]">
+      <FlameMeter level={heatTier(count)} />
+      <span
+        className={clsx(
+          "font-mono text-meta",
+          hasShows ? "text-gold" : "text-faint",
+        )}
+      >
+        {hasShows ? `${count} upcoming` : "No shows"}
+      </span>
     </div>
   );
 }
 
+const LEGEND_ITEMS: { level: number; label: string }[] = [
+  { level: 0, label: "No shows" },
+  { level: 1, label: "1–4 shows" },
+  { level: 2, label: "5–8 shows" },
+  { level: 3, label: "9+ shows" },
+];
+
+/**
+ * Heat legend row for the Comics toolbar: an "Upcoming shows" label followed
+ * by the four FlameMeter tiers.
+ */
 export function Legend() {
   return (
-    <div className="flex flex-col sm:flex-row item-center sm:space-x-2">
-      <div className="flex items-center">
-        <div className="relative fill-neutral-400">
-          <FireIcon className="h-5 w-5 fill-neutral-400" />
+    <div className="flex flex-wrap items-center gap-x-[22px] gap-y-2">
+      <span className="font-mono uppercase text-meta tracking-wider text-faint">
+        Upcoming shows
+      </span>
+      {LEGEND_ITEMS.map((item) => (
+        <div key={item.level} className="flex items-center gap-2">
+          <FlameMeter level={item.level} />
+          <span className="font-mono text-[11px] text-muted">{item.label}</span>
         </div>
-        <span className="ml-2">No Shows</span>
-      </div>
-      <span className="hidden sm:block"> | </span>
-      <div className="flex items-center">
-        <ActivityIcon />
-        <span className="ml-2">1-4 Shows</span>
-      </div>
-      <span className="hidden sm:block"> | </span>{" "}
-      <div className="flex items-center">
-        <ActivityIcon />
-        <ActivityIcon />
-        <span className="ml-2">5-8 Shows</span>
-      </div>
-      <span className="hidden sm:block"> | </span>{" "}
-      <div className="flex items-center">
-        <ActivityIcon />
-        <ActivityIcon />
-        <ActivityIcon />
-        <span className="ml-2">9+ Shows</span>
-      </div>
+      ))}
     </div>
   );
 }

--- a/packages/frontend/src/pages/Comics/index.tsx
+++ b/packages/frontend/src/pages/Comics/index.tsx
@@ -3,7 +3,7 @@ import { ComicItem, ComicItemSkeleton } from "./ComicItem";
 
 import { Legend } from "./ShowCount";
 import { SearchInput } from "../../components/SearchInput";
-import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import { PageHeader } from "../../components/ui/PageHeader";
 import { fetchComics } from "../../utils/api";
 import { useEffect, useState } from "preact/hooks";
 import { useInfiniteQuery } from "@tanstack/react-query";
@@ -42,7 +42,6 @@ export default function Comics() {
     });
 
   const allComics = data?.pages.flatMap((page) => page.results) ?? [];
-  const totalCount = data?.pages?.[0]?.total ?? 0;
   const hasResults = allComics.length > 0;
   const showNoResults =
     !isLoading && !isFetching && searchTerm.length >= 2 && !hasResults;
@@ -74,41 +73,27 @@ export default function Comics() {
   };
 
   return (
-    <div className="flex flex-col gap-y-8">
-      {/* Search Section */}
-      <div className="flex flex-col gap-4 p-4 rounded-lg ring-1 ring-gray-200 shadow-sm hover:shadow-md">
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-          <h6 className="text-md font-bold">Search Comics</h6>
-          {searchTerm.length >= 2 && (
-            <span className="text-sm text-gray-600">
-              {totalCount} result{totalCount !== 1 ? "s" : ""} for "{searchTerm}
-              "
-            </span>
-          )}
-        </div>
+    <div className="mx-auto flex max-w-[1180px] flex-col gap-8">
+      <PageHeader eyebrow="The Lineup" title="Meet the Comics" />
+
+      {/* Toolbar */}
+      <div className="rounded-panel border-hair border-line bg-surface px-[22px] py-5 shadow-block-md">
         <SearchInput
-          placeholder="Search by comic name..."
+          placeholder="Search by comic name…"
           value={searchTerm}
           onSearch={handleSearch}
           loading={isFetching && !isLoading}
-          className="max-w-md"
         />
 
-        <span className="text-md font-bold">Upcoming shows</span>
-        <Legend />
+        <div className="mt-4">
+          <Legend />
+        </div>
       </div>
 
       {/* No Results State */}
       {showNoResults && (
-        <div className="flex flex-col items-center justify-center py-12 text-center">
-          <MagnifyingGlassIcon className="mx-auto h-12 w-12 text-gray-400" />
-          <h3 className="mt-2 text-sm font-medium text-gray-900">
-            No comics found
-          </h3>
-          <p className="mt-1 text-sm text-gray-500">
-            No comics match your search for "{searchTerm}". Try a different
-            search term.
-          </p>
+        <div className="py-12 text-center font-mono text-caption text-faint">
+          No comics match “{searchTerm}”.
         </div>
       )}
 
@@ -116,7 +101,7 @@ export default function Comics() {
       {showInitialSkeletons && (
         <ul
           role="list"
-          className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:mx-0 lg:max-w-none lg:grid-cols-4"
+          className="grid grid-cols-1 gap-[22px] sm:grid-cols-2 lg:grid-cols-4"
         >
           {Array.from({ length: 12 }).map((_, index) => (
             <ComicItemSkeleton key={`initial-skeleton-${index}`} />
@@ -128,7 +113,7 @@ export default function Comics() {
       {!showInitialSkeletons && (
         <ul
           role="list"
-          className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:mx-0 lg:max-w-none lg:grid-cols-4"
+          className="grid grid-cols-1 gap-[22px] sm:grid-cols-2 lg:grid-cols-4"
         >
           {allComics.map((comic) => (
             <ComicItem key={comic.name} comic={comic} />

--- a/packages/frontend/src/pages/Gallery/index.tsx
+++ b/packages/frontend/src/pages/Gallery/index.tsx
@@ -147,7 +147,7 @@ export default function Gallery() {
         <Section title="SegmentedToggle" note="Controlled — click to switch">
           <div className="flex flex-wrap items-center gap-6">
             <div className="flex flex-col gap-2">
-              <SegmentedToggle
+              <SegmentedToggle<"relaxed" | "compact">
                 options={[
                   { label: "Relaxed", value: "relaxed" },
                   { label: "Compact", value: "compact" },
@@ -158,7 +158,7 @@ export default function Gallery() {
               <span className="font-mono text-meta text-muted">mode: {mode}</span>
             </div>
             <div className="flex flex-col gap-2">
-              <SegmentedToggle
+              <SegmentedToggle<"settings" | "profile">
                 options={[
                   { label: "Settings", value: "settings" },
                   { label: "Profile", value: "profile" },

--- a/packages/frontend/src/pages/Home/CompactRow.tsx
+++ b/packages/frontend/src/pages/Home/CompactRow.tsx
@@ -1,0 +1,91 @@
+import clsx from "clsx";
+
+import { Link } from "../../components/Link";
+import { StatusPill } from "../../components/ui/StatusPill";
+import { ProgressBar } from "../../components/ui/ProgressBar";
+import { Show } from "../../types";
+import { getShowView } from "./types";
+
+const GRID = "grid-cols-[62px_minmax(0,1fr)_104px_88px_108px]";
+
+/**
+ * Dense one-line variant of a show row for the "Compact" view mode. Same data
+ * and reserve routing as the relaxed `Event` card, laid out as a grid.
+ */
+export function CompactRow({ show }: { show: Show }) {
+  const view = getShowView(show);
+
+  return (
+    <div
+      className={clsx(
+        "grid items-center gap-[13px] rounded-[10px] border-hair border-line bg-surface py-[7px] pl-[7px] pr-3.5 shadow-block-sm transition hover:-translate-x-px hover:-translate-y-px hover:shadow-block",
+        GRID
+      )}
+    >
+      {/* Time stub */}
+      <div
+        className={clsx(
+          "rounded-[7px] border-hair border-line py-[5px] text-center",
+          view.closed ? "bg-stub" : "bg-brand"
+        )}
+      >
+        <div
+          className={clsx(
+            "font-display text-[21px] leading-[0.95]",
+            view.closed ? "text-stub-ink" : "text-brand-fg"
+          )}
+        >
+          {view.time}
+        </div>
+        <div
+          className={clsx(
+            "font-mono text-[9px]",
+            view.closed ? "text-stub-ink" : "text-brand-fg"
+          )}
+        >
+          {view.ampm}
+        </div>
+      </div>
+
+      {/* Title + venue */}
+      <div className="min-w-0">
+        <div
+          className="truncate font-sans text-caption font-bold text-text"
+          title={show.description}
+        >
+          {view.title}
+        </div>
+        <div className="truncate font-mono text-[11px] text-muted">
+          {view.venue}
+        </div>
+      </div>
+
+      {/* Seats + progress */}
+      <div>
+        <div className="mb-1 font-mono text-meta text-muted">
+          {view.capLabel}
+        </div>
+        <ProgressBar pct={view.pct} status={view.status} />
+      </div>
+
+      {/* Status */}
+      <StatusPill status={view.status} className="justify-self-center" />
+
+      {/* Action */}
+      <div className="justify-self-end">
+        {view.reservable ? (
+          <Link
+            href={`/reservations/${show.timestamp}`}
+            className="inline-flex items-center whitespace-nowrap rounded-pill bg-solid px-3.5 py-2 font-sans text-[12px] font-bold text-solid-fg! no-underline transition hover:bg-brand hover:text-brand-fg! hover:no-underline"
+          >
+            Reserve &rarr;
+          </Link>
+        ) : (
+          <span className="whitespace-nowrap font-mono text-meta text-faint">
+            Closed
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/pages/Home/index.tsx
+++ b/packages/frontend/src/pages/Home/index.tsx
@@ -4,13 +4,30 @@ import { fetchLineUp, fetchShows } from "../../utils/api";
 import { Calendar } from "../../components/Calendar";
 import { Event } from "../../components/Event";
 import { EventLoader } from "../../components/EventLoader";
+import { PageHeader } from "../../components/ui/PageHeader";
+import { SegmentedToggle } from "../../components/ui/SegmentedToggle";
+import { CompactRow } from "./CompactRow";
+import type { ViewMode } from "./types";
 import { getToday } from "../../utils/date";
-import { useEffect } from "preact/hooks";
+import { format, isPast } from "date-fns";
+import { useEffect, useState } from "preact/hooks";
 import { useLocation } from "preact-iso";
 import { useQuery } from "@tanstack/react-query";
 
+const VIEW_OPTIONS: { label: string; value: ViewMode }[] = [
+  { label: "Relaxed", value: "relaxed" },
+  { label: "Compact", value: "compact" },
+];
+
+function formatEyebrowDate(date: string): string {
+  const [year, month, day] = date.split("-").map((part) => parseInt(part, 10));
+  if (!year || !month || !day) return "";
+  return format(new Date(year, month - 1, day), "EEEE · MMMM d, yyyy");
+}
+
 export default function Home() {
   const { query, route } = useLocation();
+  const [mode, setMode] = useState<ViewMode>("relaxed");
 
   useEffect(() => {
     // I shouldn't have to check pathname here bc the home component should unmount when the path changes but its not and IDK why
@@ -55,68 +72,124 @@ export default function Home() {
     route(`?date=${date}`);
   };
 
-  return (
+  const shows = showData.data ?? [];
+  const showCount = shows.length;
+  const roomCount = new Set(shows.map((show) => show.roomId)).size;
+  const availableCount = shows.filter(
+    (show) => !show.soldout && !isPast(new Date(show.timestamp * 1000))
+  ).length;
+
+  const subline = showData.isLoading ? (
+    "Loading tonight's lineup…"
+  ) : (
     <>
-      <h2 className="text-base font-semibold leading-6 text-gray-900">
-        Upcoming Shows
-      </h2>
-      <div className="lg:grid lg:grid-cols-12 lg:gap-x-16">
-        <div className="mt-10 text-center lg:col-start-1 lg:col-end-5 lg:row-start-1 lg:mt-9">
-          <Calendar value={query.date} onChange={handleDateChange} />
-        </div>
-        <div className="mt-4 overflow-hidden rounded-lg bg-white shadow-sm ring-1 ring-gray-200 lg:col-span-7 xl:col-span-8 ">
-          <div className="px-4 py-5 sm:p-4">
-            {showData.isLoading ? (
-              <Loader />
-            ) : (
-              <ol className="divide-y divide-gray-100 text-sm leading-6">
-                {showData.data && showData.data.length ? (
-                  showData.data.map((show) => (
-                    <li
-                      key={show.id}
-                      data-timestamp={show.timestamp}
-                      className="relative xl:static py-4 first:pt-0 last:pb-0"
-                    >
-                      <Event
-                        show={show}
-                        lineUp={
-                          (!lineUpData.isLoading &&
-                            findLineUp(show.timestamp)) ?? {
-                            reservationUrl: "",
-                            timestamp: 0,
-                            acts: [],
-                          }
-                        }
-                        isLineUpLoading={lineUpData.isLoading}
-                      />
-                    </li>
-                  ))
-                ) : (
-                  <li className="relative flex space-x-6 xl:static py-4 first:pt-0 last:pb-0 ">
-                    <div className="flex space-x-3 md:space-x-6">
-                      <h3 className="font-semibold text-gray-900">
-                        No shows found for this date
-                      </h3>
-                    </div>
-                  </li>
-                )}
-              </ol>
-            )}
-          </div>
-        </div>
-      </div>
+      {showCount} {showCount === 1 ? "show" : "shows"} across {roomCount}{" "}
+      {roomCount === 1 ? "room" : "rooms"} —{" "}
+      <span className="font-bold text-success">
+        {availableCount} still available
+      </span>
     </>
+  );
+
+  return (
+    <div className="mx-auto w-full max-w-[1180px] bg-bg text-text">
+      <PageHeader
+        eyebrow={formatEyebrowDate(query.date)}
+        title="Tonight at the Cellar"
+        subline={subline}
+      />
+
+      <div className="mt-7 grid grid-cols-1 items-start gap-8 md:grid-cols-[288px_1fr]">
+        {/* Calendar */}
+        <aside>
+          <Calendar value={query.date} onChange={handleDateChange} />
+        </aside>
+
+        {/* Shows list */}
+        <section>
+          <div className="mb-[18px] flex items-end justify-between gap-4">
+            <h2 className="font-display text-d-sm tracking-cap text-text">
+              Upcoming Shows
+            </h2>
+            <div className="flex items-center gap-2.5">
+              <span className="font-mono text-meta uppercase tracking-wide text-faint">
+                View
+              </span>
+              <SegmentedToggle<ViewMode>
+                options={VIEW_OPTIONS}
+                value={mode}
+                onChange={setMode}
+              />
+            </div>
+          </div>
+
+          {showData.isLoading ? (
+            <Loader />
+          ) : shows.length ? (
+            mode === "relaxed" ? (
+              <ol className="flex flex-col gap-[15px]">
+                {shows.map((show) => (
+                  <li key={show.id} data-timestamp={show.timestamp}>
+                    <Event
+                      show={show}
+                      lineUp={
+                        (!lineUpData.isLoading &&
+                          findLineUp(show.timestamp)) ?? {
+                          reservationUrl: "",
+                          timestamp: 0,
+                          acts: [],
+                        }
+                      }
+                      isLineUpLoading={lineUpData.isLoading}
+                    />
+                  </li>
+                ))}
+              </ol>
+            ) : (
+              <div>
+                <div className="grid grid-cols-[62px_minmax(0,1fr)_104px_88px_108px] items-center gap-[13px] px-[7px] pb-2 pr-3.5">
+                  <span />
+                  <span className="font-mono text-meta uppercase tracking-wide text-faint">
+                    Show
+                  </span>
+                  <span className="font-mono text-meta uppercase tracking-wide text-faint">
+                    Seats
+                  </span>
+                  <span className="justify-self-center font-mono text-meta uppercase tracking-wide text-faint">
+                    Status
+                  </span>
+                  <span />
+                </div>
+                <ol className="flex flex-col gap-[9px]">
+                  {shows.map((show) => (
+                    <li key={show.id} data-timestamp={show.timestamp}>
+                      <CompactRow show={show} />
+                    </li>
+                  ))}
+                </ol>
+              </div>
+            )
+          ) : (
+            <div className="rounded-card border-hair border-line bg-surface p-8 text-center shadow-block">
+              <h3 className="font-display text-d-sm text-text">
+                No shows found for this date
+              </h3>
+              <p className="mt-1 font-sans text-caption text-muted">
+                Try picking another date on the calendar.
+              </p>
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
   );
 }
 
 function Loader() {
   return (
-    <ol className="divide-y divide-gray-100 text-sm leading-6">
-      {new Array(10).fill(0).map((_, index) => (
-        <li
-          key={index}
-          className="relative flex space-x-6 xl:static py-4 first:pt-0 last:pb-0 "
-        >
+    <ol className="flex flex-col gap-[15px]">
+      {new Array(8).fill(0).map((_, index) => (
+        <li key={index}>
           <EventLoader />
         </li>
       ))}

--- a/packages/frontend/src/pages/Home/types.ts
+++ b/packages/frontend/src/pages/Home/types.ts
@@ -1,0 +1,84 @@
+import { format, isPast } from "date-fns";
+
+import type { Show } from "../../types";
+import type { StatusPillStatus } from "../../components/ui/StatusPill";
+import { WARNING_OCCUPANCY_RATE } from "../../utils/constants";
+
+/** View mode for the Upcoming Shows list. */
+export type ViewMode = "relaxed" | "compact";
+
+/** Availability status shared by StatusPill + ProgressBar. */
+export type ShowStatus = StatusPillStatus; // "available" | "selling-fast" | "sold-out" | "ended"
+
+/**
+ * Presentation view-model derived from a `Show`. All display-only fields — the
+ * underlying `Show` data and the reserve/expand behavior stay untouched.
+ */
+export type ShowView = {
+  time: string; // "1:30"
+  ampm: string; // "PM"
+  title: string;
+  venue: string;
+  reservedSeats: number;
+  max: number;
+  capLabel: string; // "176 / 190"
+  pct: number; // 0..100 occupancy
+  status: ShowStatus;
+  soldOut: boolean;
+  isEventOver: boolean;
+  reservable: boolean; // reservations open (mirrors the existing gate)
+  closed: boolean; // reservations closed (past or sold out)
+  dateTimeString: string; // ISO for <time dateTime>
+};
+
+/**
+ * Derive the ticket-stub view-model from a `Show`. Mirrors the existing
+ * availability/reserve logic in `Event` (soldout, occupancy warning, isPast)
+ * so behavior is unchanged — this only maps those flags to display tokens.
+ */
+export function getShowView(show: Show): ShowView {
+  const {
+    showName,
+    soldout,
+    roomName,
+    timestamp,
+    occupancyRate,
+    totalGuests,
+    max,
+  } = show;
+
+  const dateTime = new Date(timestamp * 1000);
+  const reservedSeats = totalGuests > max ? max : totalGuests;
+  const isEventOver = isPast(dateTime);
+  const isNearingCapacity =
+    occupancyRate > WARNING_OCCUPANCY_RATE && occupancyRate < 1;
+  const pct = max > 0 ? Math.round((reservedSeats / max) * 100) : 0;
+
+  let status: ShowStatus = "available";
+  if (soldout) {
+    status = "sold-out";
+  } else if (isEventOver) {
+    status = "ended";
+  } else if (isNearingCapacity) {
+    status = "selling-fast";
+  }
+
+  const reservable = !isEventOver && !soldout;
+
+  return {
+    time: format(dateTime, "h:mm"),
+    ampm: format(dateTime, "a"),
+    title: showName,
+    venue: roomName,
+    reservedSeats,
+    max,
+    capLabel: `${reservedSeats} / ${max}`,
+    pct,
+    status,
+    soldOut: soldout,
+    isEventOver,
+    reservable,
+    closed: !reservable,
+    dateTimeString: dateTime.toISOString(),
+  };
+}

--- a/packages/frontend/src/pages/NotFound/index.tsx
+++ b/packages/frontend/src/pages/NotFound/index.tsx
@@ -1,21 +1,21 @@
+import { Eyebrow } from "../../components/ui/Eyebrow";
+import { Link } from "../../components/Link";
+
 export default function NotFound() {
   return (
-    <div className="flex justify-center items-center h-[calc(100vh-72px)]">
-      <div className="text-center">
-        <p className="text-base font-semibold text-primary">404</p>
-        <h1 className="mt-4 text-3xl font-bold tracking-tight text-gray-900 sm:text-5xl">
-          Not Found
+    <div className="flex min-h-[calc(100vh-72px)] items-center justify-center px-6">
+      <div className="flex flex-col items-center text-center">
+        <Eyebrow>Error 404</Eyebrow>
+        <h1 className="mt-2 font-display text-d-lg leading-none tracking-tightcap text-text sm:text-d-xl">
+          Lost your ticket?
         </h1>
-        <p className="mt-6 text-base leading-7 text-gray-600">
+        <p className="mt-4 max-w-md font-sans text-body leading-relaxed text-muted">
           Sorry, we couldn&apos;t find the page you&apos;re looking for.
         </p>
-        <div className="mt-10 flex items-center justify-center gap-x-6">
-          <a
-            href="/"
-            className="rounded-md bg-primary px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-white hover:text-primary hover:border-primary focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-          >
+        <div className="mt-8">
+          <Link href="/" variant="underline">
             Go back home
-          </a>
+          </Link>
         </div>
       </div>
     </div>

--- a/packages/frontend/src/pages/Profile/index.tsx
+++ b/packages/frontend/src/pages/Profile/index.tsx
@@ -5,6 +5,10 @@ import PageWrapper from "../Auth/PageWrapper";
 import { ProfileSettings } from "./profileSettings";
 import { clerk } from "../../utils/clerk";
 
+import { Card, CardBody, CardHeader } from "../../components/Card";
+import { Eyebrow } from "../../components/ui/Eyebrow";
+import { PageHeader } from "../../components/ui/PageHeader";
+
 enum ProfileTabName {
   Settings = "Settings",
   Profile = "Profile",
@@ -20,16 +24,32 @@ export default function Profile() {
 
   return (
     <PageWrapper>
-      <div className="flex flex-col w-full">
+      <div className="w-full max-w-[820px] px-6 pb-16">
+        <PageHeader
+          eyebrow="Your Account"
+          title="Backstage Pass"
+          className="mb-7"
+        />
+
         <ProfileTabs>
           <ProfileTabContent tabName={ProfileTabName.Settings}>
             <ProfileSettings />
           </ProfileTabContent>
 
           <ProfileTabContent tabName={ProfileTabName.Profile}>
-            <div className="flex justify-center">
-              <div ref={profileRef} />
-            </div>
+            <Card>
+              <CardHeader>
+                <Eyebrow>Account</Eyebrow>
+                <h3 className="mt-1 font-display text-d-sm tracking-cap text-text">
+                  Your Details
+                </h3>
+              </CardHeader>
+              <CardBody>
+                <div className="flex justify-center">
+                  <div ref={profileRef} />
+                </div>
+              </CardBody>
+            </Card>
           </ProfileTabContent>
         </ProfileTabs>
       </div>

--- a/packages/frontend/src/pages/Profile/profileSettings.tsx
+++ b/packages/frontend/src/pages/Profile/profileSettings.tsx
@@ -7,7 +7,9 @@ import { Button } from "../../components/Button";
 import { Checkbox } from "../../components/Checkbox";
 import { Link } from "../../components/Link";
 import { PageLoader } from "../../components/PageLoader";
-import { Spinner } from "../../components/Spinner";
+
+import { Avatar } from "../../components/ui/Avatar";
+import { Pill } from "../../components/ui/Pill";
 
 export function ProfileSettings() {
   const { data, isLoading } = useQuery<Settings>({
@@ -30,25 +32,28 @@ export function ProfileSettings() {
   if (isLoading) {
     return <PageLoader />;
   }
+
   return (
-    <div className="space-y-5">
+    <div className="flex flex-col gap-[22px]">
       <Card>
         <CardHeader>
-          <h3 className="text-base font-semibold text-gray-900">
+          <h3 className="font-display text-d-sm tracking-cap text-text">
             Global Notifications
           </h3>
-          <p className="mt-1 text-sm text-gray-500">System setting below</p>
+          <p className="mt-1 font-mono text-[11px] text-faint">
+            System-wide setting
+          </p>
         </CardHeader>
         <CardBody>
-          <form className="flex flex-col gap-2" onSubmit={handleSubmit}>
+          <form className="flex flex-col gap-5" onSubmit={handleSubmit}>
             <Checkbox
               label="showNotification"
-              displayLabel="Show Notification"
-              description="Get whenever any new shows are added (this is independent of comic notifications)"
+              displayLabel="New Show Alerts"
+              description="Get a heads-up whenever any new show is added — independent of comic notifications."
               defaultChecked={data?.showNotification.enabled ?? false}
             />
             <div className="flex justify-end">
-              <Button type="submit" disabled={isPending}>
+              <Button type="submit" variant="solid" disabled={isPending}>
                 {isPending ? "Saving..." : "Save"}
               </Button>
             </div>
@@ -58,72 +63,52 @@ export function ProfileSettings() {
 
       <Card>
         <CardHeader>
-          <h3 className="text-base font-semibold text-gray-900">
+          <h3 className="font-display text-d-sm tracking-cap text-text">
             Comic Notifications
           </h3>
-          <p className="mt-1 text-sm text-gray-500">
-            You'll be notified when a comic is assigned to a show.
-          </p>
-          <p className="mt-1 text-sm text-gray-500">
-            You can disable notifications for by going to the comic's profile
-            page.
+          <p className="mt-1 font-sans text-caption text-muted">
+            You'll be notified when a tracked comic is added to a show. Manage
+            each comic from its profile page.
           </p>
         </CardHeader>
         <CardBody>
-          <ComicNotificationList
-            comicNotifications={data?.comicNotifications}
-          />
+          <ComicNotificationList comicNotifications={data?.comicNotifications} />
         </CardBody>
       </Card>
     </div>
   );
 }
 
-export function Badge({ enabled }: { enabled: boolean }) {
-  const color = enabled
-    ? "bg-green-50 text-green-700 ring-green-600/20"
-    : "bg-red-50 text-red-700 ring-red-600/20";
-  return (
-    <span
-      className={`inline-flex items-center rounded-md ${color} px-2 py-1 text-xs font-medium ring-1 ring-inset`}
-    >
-      {enabled ? "Enabled" : "Disabled"}
-    </span>
+function NotificationPill({ enabled }: { enabled: boolean }) {
+  return enabled ? (
+    <Pill className="border-success bg-success-soft text-success">Enabled</Pill>
+  ) : (
+    <Pill className="text-faint">Muted</Pill>
   );
 }
 
 export function ComicNotificationList({
   comicNotifications,
 }: {
-  comicNotifications: ComicNotification[];
+  comicNotifications?: ComicNotification[];
 }) {
   return (
-    <ul role="list" className="flex flex-col divide-y divide-gray-100 pad-y-5">
-      {comicNotifications.map((comicNotification) => (
+    <ul role="list" className="flex flex-col divide-y divide-track">
+      {(comicNotifications ?? []).map((comicNotification) => (
         <li
           key={comicNotification.comicId}
-          className="flex justify-between gap-x-6"
+          className="flex items-center justify-between gap-4 py-3.5 first:pt-0 last:pb-0"
         >
-          <div className="flex min-w-0 gap-x-4">
-            <img
-              alt={`${comicNotification.name} comic image`}
-              src={comicNotification.comic}
-              className="size-12 flex-none rounded-full bg-gray-50"
-            />
-            <div className="min-w-0 flex-auto">
-              <Link
-                href={`/comics/${comicNotification.comicId}`}
-                className="text-sm/6 font-semibold text-gray-900"
-              >
-                {comicNotification.name}
-              </Link>
-            </div>
+          <div className="flex min-w-0 items-center gap-3.5">
+            <Avatar name={comicNotification.name} size={42} />
+            <Link
+              href={`/comics/${comicNotification.comicId}`}
+              className="truncate text-body font-bold text-text"
+            >
+              {comicNotification.name}
+            </Link>
           </div>
-          <div className="hidden shrink-0 sm:flex sm:flex-col sm:items-end">
-            <p className="text-sm/6 text-gray-900">
-              <Badge enabled={comicNotification.enabled} />
-            </p>
-          </div>
+          <NotificationPill enabled={comicNotification.enabled} />
         </li>
       ))}
     </ul>

--- a/packages/frontend/src/pages/Profile/profileTabs.tsx
+++ b/packages/frontend/src/pages/Profile/profileTabs.tsx
@@ -1,11 +1,8 @@
 import * as Preact from "preact";
 
-import { ChevronDownIcon } from "@heroicons/react/16/solid";
 import { useState } from "preact/hooks";
 
-function classNames(...classes) {
-  return classes.filter(Boolean).join(" ");
-}
+import { SegmentedToggle } from "../../components/ui/SegmentedToggle";
 
 export function ProfileTabs({ children }: { children: React.ReactNode }) {
   const childrenArray = Preact.toChildArray(children);
@@ -29,46 +26,14 @@ export function ProfileTabs({ children }: { children: React.ReactNode }) {
 
   return (
     <div className="flex flex-col gap-8">
-      <div className="grid grid-cols-1 sm:hidden">
-        <select
-          defaultValue={activeTab}
-          aria-label="Select a tab"
-          className="col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-2 pl-3 pr-8 text-base text-gray-900 outline-solid outline-1 -outline-offset-1 outline-gray-300 focus:outline-solid focus:outline-2 focus:-outline-offset-2 focus:outline-primary"
-          onChange={(e) => setActiveTab((e.target as HTMLSelectElement).value)}
-        >
-          {tabNames.map((tabName) => (
-            <option key={tabName} value={tabName}>
-              {tabName}
-            </option>
-          ))}
-        </select>
-        <ChevronDownIcon
-          aria-hidden="true"
-          className="pointer-events-none col-start-1 row-start-1 mr-2 size-5 self-center justify-self-end fill-gray-500"
-        />
-      </div>
-      <div className="hidden sm:block">
-        <div className="border-b border-gray-200">
-          <nav aria-label="Tabs" className="-mb-px grid grid-cols-4">
-            {tabNames.map((tabName) => (
-              <button
-                key={tabName}
-                type="button"
-                onClick={() => setActiveTab(tabName)}
-                aria-current={activeTab === tabName ? "page" : undefined}
-                className={classNames(
-                  activeTab === tabName
-                    ? "border-black text-black"
-                    : "border-transparent text-gray-500 hover:border-primary hover:text-primary transition-all duration-200",
-                  "col-span-2 border-b-2 px-1 py-4 text-center text-sm font-medium"
-                )}
-              >
-                {tabName}
-              </button>
-            ))}
-          </nav>
-        </div>
-      </div>
+      <SegmentedToggle
+        options={tabNames.map((tabName) => ({
+          label: tabName,
+          value: tabName,
+        }))}
+        value={activeTab}
+        onChange={setActiveTab}
+      />
       <div>{newChildren}</div>
     </div>
   );

--- a/packages/frontend/src/pages/Reservations/FormError.tsx
+++ b/packages/frontend/src/pages/Reservations/FormError.tsx
@@ -10,18 +10,18 @@ export function FormError({
 }) {
   const errorLength = errors.length;
   return (
-    <div className="rounded-md bg-red-50 p-4">
+    <div className="rounded-card border-hair border-danger bg-danger-soft p-4">
       <div className="flex">
         <div className="shrink-0">
-          <XCircleIcon className="h-5 w-5 text-red-400" aria-hidden="true" />
+          <XCircleIcon className="size-5 text-danger" aria-hidden="true" />
         </div>
         <div className="ml-3">
-          <h3 className="text-sm font-medium text-red-800">
+          <h3 className="font-sans text-caption font-semibold text-danger">
             There{" "}
             {errorLength > 1 ? `were ${errorLength} errors` : `is 1 error`} with
             your submission
           </h3>
-          <div className="mt-2 text-sm text-red-700">
+          <div className="mt-2 font-sans text-caption text-danger">
             <ul role="list" className="list-disc space-y-1 pl-5">
               {errors.map((error) => (
                 <li key={error.field}>

--- a/packages/frontend/src/pages/Reservations/FormSuccess.tsx
+++ b/packages/frontend/src/pages/Reservations/FormSuccess.tsx
@@ -2,23 +2,23 @@ import { CheckCircleIcon } from "@heroicons/react/20/solid";
 
 export function FormSuccess({ message }: { message: string }) {
   return (
-    <div className="rounded-md bg-green-50 p-4">
+    <div className="rounded-card border-hair border-success bg-success-soft p-4">
       <div className="flex">
         <div className="shrink-0">
           <CheckCircleIcon
-            className="h-5 w-5 text-green-400"
+            className="size-5 text-success"
             aria-hidden="true"
           />
         </div>
         <div className="ml-3">
-          <h3 className="text-sm font-medium text-green-800">
+          <h3 className="font-sans text-caption font-semibold text-success">
             Order completed
           </h3>
-          <small className="text-sm text-green-800">
+          <small className="font-sans text-caption text-success">
             A message from the Cellar:
           </small>
           <div
-            className="mt-2 text-sm text-green-700"
+            className="mt-2 font-sans text-caption text-success"
             dangerouslySetInnerHTML={{ __html: message }}
           ></div>
           <div className="mt-4">

--- a/packages/frontend/src/pages/Reservations/Helpers.tsx
+++ b/packages/frontend/src/pages/Reservations/Helpers.tsx
@@ -1,27 +1,43 @@
-export const Section: React.FC<{ title: string; description?: string }> = ({
+import type { ComponentChildren } from "preact";
+
+export const Section = ({
   title,
   description,
   children,
+}: {
+  title: string;
+  description?: string;
+  children: ComponentChildren;
 }) => (
-  <div className="pb-4">
-    <h2 className="text-base font-semibold leading-7 text-gray-900">{title}</h2>
-    <p className="mt-1 text-sm leading-6 text-gray-600">{description}</p>
+  <div className="pb-6">
+    <h2 className="font-display text-d-sm tracking-cap text-text">{title}</h2>
+    {description ? (
+      <p className="mt-1 font-sans text-caption text-muted">{description}</p>
+    ) : null}
+    <div className="mt-4">{children}</div>
+  </div>
+);
+
+export const Field = ({
+  label,
+  labelText,
+  children,
+}: {
+  label: string;
+  labelText: string;
+  children: ComponentChildren;
+}) => (
+  <div>
+    <label
+      htmlFor={label}
+      className="mb-[7px] block font-mono text-meta uppercase text-muted"
+    >
+      {labelText}
+    </label>
     {children}
   </div>
 );
 
-export const Field = ({ label, labelText, children }) => (
-  <div className="">
-    <label
-      htmlFor={label}
-      className="block text-sm font-medium leading-6 text-gray-900"
-    >
-      {labelText}
-    </label>
-    <div className="mt-2">{children}</div>
-  </div>
-);
-
-export const FieldWrapper = ({ children }) => (
-  <div className="mt-2 grid grid-cols-1 gap-x-2 gap-y-2">{children}</div>
+export const FieldWrapper = ({ children }: { children: ComponentChildren }) => (
+  <div className="grid grid-cols-1 gap-4">{children}</div>
 );

--- a/packages/frontend/src/pages/Reservations/NetworkError.tsx
+++ b/packages/frontend/src/pages/Reservations/NetworkError.tsx
@@ -12,20 +12,22 @@ export function NetworkError({ message }: { message: string }) {
     return null;
   }
   return (
-    <div className="rounded-md bg-red-50 p-4 py-6">
+    <div className="rounded-card border-hair border-danger bg-danger-soft p-4">
       <div className="flex">
         <div className="shrink-0">
-          <XCircleIcon className="h-5 w-5 text-red-400" aria-hidden="true" />
+          <XCircleIcon className="size-5 text-danger" aria-hidden="true" />
         </div>
         <div className="ml-3">
-          <h3 className="text-sm font-medium text-red-800">{message}</h3>
+          <h3 className="font-sans text-caption font-semibold text-danger">
+            {message}
+          </h3>
         </div>
         <div className="ml-auto pl-3">
           <div className="-mx-1.5 -my-1.5">
             <button
               type="button"
               onClick={dismissError}
-              className="inline-flex rounded-md bg-red-50 p-1.5 text-red-500 hover:bg-red-100 focus:outline-hidden focus:ring-2 focus:ring-red-600 focus:ring-offset-2 focus:ring-offset-red-50"
+              className="inline-flex rounded-field p-1.5 text-danger transition hover:bg-danger/10 focus:outline-none focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-danger"
             >
               <span className="sr-only">Dismiss</span>
               <XMarkIcon className="h-5 w-5" aria-hidden="true" />

--- a/packages/frontend/src/pages/Reservations/PageError.tsx
+++ b/packages/frontend/src/pages/Reservations/PageError.tsx
@@ -1,18 +1,18 @@
 export function PageError() {
   return (
-    <div className="flex justify-center items-center h-[calc(100vh-72px)]">
+    <div className="flex h-[calc(100vh-72px)] items-center justify-center">
       <div className="text-center">
-        <p className="text-base font-semibold text-primary">500</p>
-        <h1 className="mt-4 text-3xl font-bold tracking-tight text-gray-900 sm:text-5xl">
-          Error
-        </h1>
-        <p className="mt-6 text-base leading-7 text-gray-600">
+        <p className="font-mono text-label uppercase tracking-widest text-gold">
+          500
+        </p>
+        <h1 className="mt-4 font-display text-d-xl text-text">Error</h1>
+        <p className="mt-6 font-sans text-body text-muted">
           Sorry, An error occured on the page you were trying to access.
         </p>
         <div className="mt-10 flex items-center justify-center gap-x-6">
           <a
             href="/"
-            className="rounded-md bg-primary px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-white hover:text-primary hover:border-primary focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            className="rounded-pill bg-solid px-5 py-3 font-sans font-semibold text-solid-fg transition hover:bg-solid-hover"
           >
             Go back home
           </a>

--- a/packages/frontend/src/pages/Reservations/ShowDetails.tsx
+++ b/packages/frontend/src/pages/Reservations/ShowDetails.tsx
@@ -1,69 +1,53 @@
-import {
-  MapPinIcon,
-  CalendarIcon,
-  UserGroupIcon,
-  MicrophoneIcon,
-} from "@heroicons/react/24/outline";
 import { LineUp, Show } from "../../types";
 import { deriveShowDetails } from "../../utils/deriveShowDetails";
+import { Avatar } from "../../components/ui/Avatar";
+import { Eyebrow } from "../../components/ui/Eyebrow";
 
 export const ShowDetails = (props: { show: Show; lineUp: LineUp }) => {
-  const { roomName, max } = props.show;
+  const { roomName, max, description } = props.show;
 
-  const { dateTime, date, time, isEventOver, reservedSeats } =
-    deriveShowDetails(props.show);
+  const { dateTime, date, time, reservedSeats } = deriveShowDetails(props.show);
 
   const showInfo = [
     {
-      label: "Show Name",
-      value: props.show.description,
-      icon: MicrophoneIcon,
-    },
-    {
-      label: "Date",
+      label: "DATE",
       value: (
         <time dateTime={dateTime.toISOString()}>
-          {date} at {time}
+          {date} · {time}
         </time>
       ),
-      icon: CalendarIcon,
     },
     {
-      label: "Location",
+      label: "ROOM",
       value: roomName,
-      icon: MapPinIcon,
     },
     {
-      label: "Occupancy Rate",
-      value: `${reservedSeats}/${max}`,
-      icon: UserGroupIcon,
+      label: "SEATS",
+      value: `${reservedSeats} / ${max}`,
     },
   ];
 
   return (
-    <>
-      <dl className="space-y-5">
+    <div>
+      <Eyebrow>Your Show</Eyebrow>
+      <h2 className="mt-1.5 font-display text-d-md leading-[0.95] text-text">
+        {description}
+      </h2>
+
+      <dl className="mt-5 flex flex-col gap-3">
         {showInfo.map((info) => (
-          <div key={info.label} className="flex rounded-lg items-center">
-            <dt className="shrink-0">
-              <div className="flow-root">
-                <span className="sr-only">{info.label}</span>
-                {<info.icon className="h-6 w-6" />}
-              </div>
-            </dt>
-            <dd className="ml-5">
-              <span className="text-sm font-medium text-gray-900">
-                {info.value}
-              </span>
-            </dd>
+          <div
+            key={info.label}
+            className="flex gap-2.5 font-mono text-meta text-text"
+          >
+            <dt className="text-gold">{info.label}</dt>
+            <dd>{info.value}</dd>
           </div>
         ))}
-        <div>
-          <span className="sr-only">Line Up</span>
-          {props.lineUp && <LineUpDetails lineUp={props.lineUp} />}
-        </div>
       </dl>
-    </>
+
+      {props.lineUp && <LineUpDetails lineUp={props.lineUp} />}
+    </div>
   );
 };
 
@@ -71,15 +55,16 @@ function LineUpDetails(props: { lineUp: LineUp }) {
   const { lineUp } = props;
 
   return (
-    <div className="flex -space-x-2 overflow-hidden">
+    <div className="mt-5 flex">
       {lineUp.acts.map((act) => (
-        <img
+        <span
           key={act.name}
-          className="inline-block h-10 w-10 rounded-full ring-2 ring-white"
-          src={act.img}
-          alt={act.name}
           title={act.name}
-        />
+          className="-mr-[7px] inline-flex"
+        >
+          <span className="sr-only">{act.name}</span>
+          <Avatar name={act.name} size={30} />
+        </span>
       ))}
     </div>
   );

--- a/packages/frontend/src/pages/Reservations/index.tsx
+++ b/packages/frontend/src/pages/Reservations/index.tsx
@@ -6,6 +6,7 @@ import { useLocation, useRoute } from "preact-iso";
 import { useMutation, useQuery } from "@tanstack/react-query";
 
 import { Button } from "../../components/Button";
+import { Checkbox } from "../../components/Checkbox";
 import { Disclaimer } from "../../components/Disclaimer";
 import { FormError } from "./FormError";
 import { FormSuccess } from "./FormSuccess";
@@ -13,9 +14,11 @@ import { Input } from "../../components/Input";
 import { Link } from "../../components/Link";
 import { NetworkError } from "./NetworkError";
 import { PageError } from "./PageError";
+import { PageHeader } from "../../components/ui/PageHeader";
 import { PageLoader } from "../../components/PageLoader";
 import { ShowDetails } from "./ShowDetails";
 import { Spinner } from "../../components/Spinner";
+import { TicketStub } from "../../components/ui/TicketStub";
 import { isPast } from "date-fns";
 
 const howHeardOptions = [
@@ -140,29 +143,36 @@ export default function Reservation() {
   const maxReservationSize = showData?.data?.room?.maxReservationSize ?? 4;
 
   return (
-    <div className="overflow-hidden rounded-lg bg-white shadow-sm">
-      <div className="px-4 py-5 sm:p-6">
-        <form onSubmit={handleSubmit}>
-          <div className="grid grid-cols-1 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-6 gap-x-5">
-            <div className="sm:hidden mb-5">
-              <ShowDetails
-                show={showData.data.show}
-                lineUp={showData.data.lineUp}
-              />
-              <hr className="mt-5" />
-            </div>
-            <div className="col-span-2 sm:col-span-2 md:col-span-3 lg:col-span-4">
-              <Section title="Reservation Information" description="">
-                <input
-                  disabled
-                  type="hidden"
-                  name="showId"
-                  value={showData.data.show.id}
-                />
+    <div className="mx-auto max-w-[1080px] pb-10">
+      <a
+        href="/"
+        className="mb-4 inline-block font-mono text-meta uppercase tracking-wider text-muted no-underline hover:text-text"
+      >
+        ‹ Back to shows
+      </a>
 
-                <input type="hidden" name="timestamp" value={timestamp} />
+      <PageHeader
+        eyebrow="You're almost in"
+        title="Reserve Your Seats"
+        className="mb-6"
+      />
 
-                <FieldWrapper>
+      <form onSubmit={handleSubmit}>
+        <div className="grid overflow-hidden rounded-2xl border-hair border-line bg-surface shadow-block-lg md:grid-cols-[1.45fr_1fr]">
+          {/* LEFT: reservation form */}
+          <div className="px-8 py-7">
+            <input
+              disabled
+              type="hidden"
+              name="showId"
+              value={showData.data.show.id}
+            />
+
+            <input type="hidden" name="timestamp" value={timestamp} />
+
+            <Section title="Reservation Information" description="">
+              <FieldWrapper>
+                <div className="grid grid-cols-2 gap-4">
                   <Field label="firstName" labelText={"First Name"}>
                     <Input
                       type="text"
@@ -182,165 +192,140 @@ export default function Reservation() {
                       autoComplete="family-name"
                     />
                   </Field>
+                </div>
 
-                  <Field
-                    label="size"
-                    labelText={`Party Size (max ${maxReservationSize})`}
+                <Field
+                  label="size"
+                  labelText={`Party Size (max ${maxReservationSize})`}
+                >
+                  <Input
+                    required
+                    type="number"
+                    name="size"
+                    id="size"
+                    max={maxReservationSize}
+                    min={1}
+                  />
+                </Field>
+              </FieldWrapper>
+            </Section>
+
+            <Section
+              title="Contact Information"
+              description="You'll receive your reservation confirmation here"
+            >
+              <FieldWrapper>
+                <Field label="email" labelText={"Email Address"}>
+                  <Input
+                    id="email"
+                    name="email"
+                    type="email"
+                    required
+                    autoComplete="email"
+                  />
+                </Field>
+
+                <Field label="emailConfirm" labelText={"Confirm Email Address"}>
+                  <Input
+                    id="emailConfirm"
+                    name="emailConfirm"
+                    type="email"
+                    required
+                    autoComplete="email"
+                  />
+                </Field>
+
+                <Field label="phone" labelText="Phone Number">
+                  <Input
+                    type="tel"
+                    name="phone"
+                    id="phone"
+                    pattern="[0-9][0-9]{9}"
+                    placeholder={"9876543210"}
+                    required
+                  />
+                </Field>
+              </FieldWrapper>
+            </Section>
+
+            <Section title="Misc">
+              <FieldWrapper>
+                <Field label="howHeard" labelText="How did you hear about us?">
+                  <select
+                    id="howHeard"
+                    name="howHeard"
+                    required
+                    className="block w-full rounded-field border-hair border-line bg-surface px-3.5 py-3 font-sans text-body text-text outline-none focus:shadow-[3px_3px_0_var(--color-brand)]"
                   >
-                    <Input
-                      required
-                      type="number"
-                      name="size"
-                      id="size"
-                      max={maxReservationSize}
-                      min={1}
-                    />
-                  </Field>
-                </FieldWrapper>
-              </Section>
+                    {howHeardOptions.map((option) => (
+                      <option key={option}>{option}</option>
+                    ))}
+                  </select>
+                </Field>
 
-              <Section
-                title="Contact Information"
-                description="You'll receive your reservation confirmation here"
-              >
-                <FieldWrapper>
-                  <Field label="email" labelText={"Email Address"}>
-                    <Input
-                      id="email"
-                      name="email"
-                      type="email"
-                      required
-                      autoComplete="email"
-                    />
-                  </Field>
-
-                  <Field
-                    label="emailConfirm"
-                    labelText={"Confirm Email Address"}
-                  >
-                    <Input
-                      id="emailConfirm"
-                      name="emailConfirm"
-                      type="email"
-                      required
-                      autoComplete="email"
-                    />
-                  </Field>
-
-                  <Field label="phone" labelText="Phone Number">
-                    <Input
-                      type="tel"
-                      name="phone"
-                      id="phone"
-                      pattern="[0-9][0-9]{9}"
-                      placeholder={"9876543210"}
-                      required
-                    />
-                  </Field>
-                </FieldWrapper>
-              </Section>
-
-              <Section title="Misc">
-                <FieldWrapper>
-                  <Field
-                    label="howHeard"
-                    labelText="How did you hear about us?
-"
-                  >
-                    <select
-                      id="howHeard"
-                      name="howHeard"
-                      required
-                      className="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:max-w-xs sm:text-sm sm:leading-6"
-                    >
-                      {howHeardOptions.map((option) => (
-                        <option key={option}>{option}</option>
-                      ))}
-                    </select>
-                  </Field>
-
-                  <div className="space-y-5">
-                    <div className="relative flex items-start">
-                      <div className="flex h-6 items-center">
-                        <input
-                          id="smsOk"
-                          aria-describedby="smsOk-description"
-                          name="smsOk"
-                          type="checkbox"
-                          className="h-4 w-4 rounded-sm border-gray-300 text-primary focus:ring-primary"
-                        />
-                      </div>
-                      <div className="ml-3 text-sm leading-6">
-                        <label
-                          htmlFor="smsOk"
-                          className="font-medium text-gray-900"
-                        >
-                          One time SMS feedback
-                        </label>
-                        <p id="comments-description" className="text-gray-500">
-                          After the show, can the cellar text you a request for
-                          your comments? The number will never be used again
-                          after.
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                </FieldWrapper>
-
-                <FormStatus
-                  formErrors={errors}
-                  mutation={reservationMutation}
+                <Checkbox
+                  label="smsOk"
+                  displayLabel="One time SMS feedback"
+                  description="After the show, can the cellar text you a request for your comments? The number will never be used again after."
                 />
-              </Section>
-            </div>
-            <div className="col-span-1 sm:col-span-2 md:col-span-3 lg:col-span-2 space-y-5">
-              <div className="hidden sm:block">
-                <ShowDetails
-                  show={showData.data.show}
-                  lineUp={showData.data.lineUp}
-                />
-              </div>
-              <hr />
-              <Disclaimer />
+              </FieldWrapper>
+            </Section>
+
+            <FormStatus formErrors={errors} mutation={reservationMutation} />
+
+            <div className="mt-6">
+              {reservationMutation.isSuccess ? (
+                <div className="flex flex-col gap-4">
+                  <FormSuccess
+                    message={reservationMutation.data.content.message}
+                  />
+                  <Link href="/" className="font-bold text-gold!">
+                    Return home
+                  </Link>
+                </div>
+              ) : (
+                <Button
+                  type="submit"
+                  variant="solid"
+                  className="w-full py-[15px]! text-body! font-extrabold!"
+                  disabled={
+                    showData.data.show.soldout ||
+                    reservationMutation.status === "pending"
+                  }
+                >
+                  {reservationMutation.status === "pending" ? (
+                    <Spinner size={5} className="text-solid-fg!" />
+                  ) : (
+                    "Reserve My Seats →"
+                  )}
+                </Button>
+              )}
             </div>
           </div>
-          {reservationMutation.isSuccess ? (
-            <>
-              <div className="py-6">
-                <FormSuccess
-                  message={reservationMutation.data.content.message}
-                />
-              </div>
-              <Link href="/">Return home</Link>
-            </>
-          ) : (
-            <div className="mt-6 flex items-center justify-between gap-x-6">
-              <Button
-                type="submit"
-                className="bg-primary"
-                disabled={
-                  showData.data.show.soldout ||
-                  reservationMutation.status === "pending"
-                }
-              >
-                {reservationMutation.status === "pending" ? (
-                  <Spinner size={5} />
-                ) : (
-                  "Submit"
-                )}
-              </Button>
-              <Link
-                target="_blank"
-                rel="noopener noreferrer"
-                href={showData.data.show.reservationUrl}
-                title={"We won't be offended"}
-              >
-                Reserve on comedycellar.com
-              </Link>
-            </div>
-          )}
-        </form>
-      </div>
+
+          {/* RIGHT: ticket stub */}
+          <TicketStub>
+            <ShowDetails
+              show={showData.data.show}
+              lineUp={showData.data.lineUp}
+            />
+
+            <div className="my-5 border-t-2 border-dashed border-line" />
+
+            <Disclaimer />
+
+            <Link
+              target="_blank"
+              rel="noopener noreferrer"
+              href={showData.data.show.reservationUrl}
+              title={"We won't be offended"}
+              className="mt-2.5 inline-block font-bold text-caption text-gold!"
+            >
+              Reserve on comedycellar.com ↗
+            </Link>
+          </TicketStub>
+        </div>
+      </form>
     </div>
   );
 }

--- a/packages/frontend/src/pages/Terms/index.tsx
+++ b/packages/frontend/src/pages/Terms/index.tsx
@@ -1,290 +1,282 @@
+import { Card, CardBody } from "../../components/Card";
+import { Link } from "../../components/Link";
+import { PageHeader } from "../../components/ui/PageHeader";
+
+const sectionTitle =
+  "mb-4 font-display text-d-md leading-none tracking-tightcap text-text";
+const subHeading = "mb-4 font-sans text-lead font-bold text-text";
+const proseP = "font-sans text-body leading-relaxed text-muted";
+const proseList =
+  "list-inside list-disc space-y-1 font-sans text-body leading-relaxed text-muted";
+const effectiveDate = "mb-8 font-mono text-caption text-muted";
+
 export default function Terms() {
   return (
-    <div className="mt-10 max-w-4xl mx-auto p-6 bg-white shadow-sm ring-1 ring-gray-200 rounded-lg">
-      <section id="terms-and-conditions" className="mb-12">
-        <h1 className="text-4xl font-bold mb-4 text-slate-950">
-          Terms and Conditions ("Terms")
-        </h1>
-        <p className="text-sm text-gray-500 mb-8">
-          <strong>Effective Date:</strong> 2024-10-01
-        </p>
+    <div className="mx-auto flex max-w-3xl flex-col gap-8 px-6 py-10">
+      <PageHeader
+        eyebrow="The Fine Print"
+        title="Terms & Privacy"
+        subline="The house rules, privacy policy, and a note from the developer."
+      />
 
-        <h2 className="text-2xl font-semibold mb-4">1. Acceptance of Terms</h2>
-        <p className="mb-4">
-          This site is a personal, non-commercial project. By using the site,
-          you agree to these Terms. If you choose to create an account to access
-          personalized features, additional terms will apply to your use.
-        </p>
+      <Card>
+        <CardBody>
+          <section id="terms-and-conditions" className="mb-12">
+            <h2 className={sectionTitle}>Terms and Conditions ("Terms")</h2>
+            <p className={effectiveDate}>
+              <strong>Effective Date:</strong> 2024-10-01
+            </p>
 
-        <h2 className="text-2xl font-semibold mb-4">
-          2. Using the Site Without an Account
-        </h2>
-        <ul className="list-disc list-inside mb-4">
-          <li>
-            Most features on the site are accessible{" "}
-            <strong>without an account</strong>.
-          </li>
-          <li>You can browse show listings and view general content freely.</li>
-          <li>You can reserve tickets to a show.</li>
-        </ul>
+            <h3 className={subHeading}>1. Acceptance of Terms</h3>
+            <p className={`${proseP} mb-4`}>
+              This site is a personal, non-commercial project. By using the site,
+              you agree to these Terms. If you choose to create an account to access
+              personalized features, additional terms will apply to your use.
+            </p>
 
-        <h2 className="text-2xl font-semibold mb-4">
-          3. Creating an Account for Personalized Features
-        </h2>
-        <ul className="list-disc list-inside mb-4">
-          <li>
-            To access individualized features (e.g., tracking new shows or
-            receiving notifications), you must create an account.
-          </li>
-          <li>
-            You are responsible for keeping your account information
-            confidential.
-          </li>
-          <li>
-            If we detect misuse (e.g., spam, multiple accounts, or improper
-            behavior), we may suspend or delete your account.
-          </li>
-        </ul>
+            <h3 className={subHeading}>2. Using the Site Without an Account</h3>
+            <ul className={`${proseList} mb-4`}>
+              <li>
+                Most features on the site are accessible{" "}
+                <strong>without an account</strong>.
+              </li>
+              <li>You can browse show listings and view general content freely.</li>
+              <li>You can reserve tickets to a show.</li>
+            </ul>
 
-        <h2 className="text-2xl font-semibold mb-4">
-          4. User Responsibilities
-        </h2>
-        <ul className="list-disc list-inside mb-4">
-          <li>You agree to use the site lawfully and respectfully.</li>
-          <li>
-            You will not engage in activities that could harm the site or
-            disrupt the experience of other users.
-          </li>
-          <li>
-            The site offers a voluntary{" "}
-            <a
-              href="https://www.buymeacoffee.com/mafzal91"
-              className="text-blue-500 underline"
-            >
-              "Buy Me a Coffee"
-            </a>{" "}
-            link. Donations are optional and do not guarantee additional
-            services or benefits.
-          </li>
-        </ul>
+            <h3 className={subHeading}>
+              3. Creating an Account for Personalized Features
+            </h3>
+            <ul className={`${proseList} mb-4`}>
+              <li>
+                To access individualized features (e.g., tracking new shows or
+                receiving notifications), you must create an account.
+              </li>
+              <li>
+                You are responsible for keeping your account information
+                confidential.
+              </li>
+              <li>
+                If we detect misuse (e.g., spam, multiple accounts, or improper
+                behavior), we may suspend or delete your account.
+              </li>
+            </ul>
 
-        <h2 className="text-2xl font-semibold mb-4">5. Third-Party Content</h2>
-        <p className="mb-4">
-          This site displays information from external sources (like TV networks
-          or public APIs). We do not own or guarantee the accuracy of this
-          content.
-        </p>
+            <h3 className={subHeading}>4. User Responsibilities</h3>
+            <ul className={`${proseList} mb-4`}>
+              <li>You agree to use the site lawfully and respectfully.</li>
+              <li>
+                You will not engage in activities that could harm the site or
+                disrupt the experience of other users.
+              </li>
+              <li>
+                The site offers a voluntary{" "}
+                <Link
+                  href="https://www.buymeacoffee.com/mafzal91"
+                  variant="underline"
+                >
+                  "Buy Me a Coffee"
+                </Link>{" "}
+                link. Donations are optional and do not guarantee additional
+                services or benefits.
+              </li>
+            </ul>
 
-        <h2 className="text-2xl font-semibold mb-4">
-          6. Modifications and Availability
-        </h2>
-        <p className="mb-4">
-          We reserve the right to change or remove features at any time without
-          notice. We do not guarantee the site will always be available or
-          error-free.
-        </p>
+            <h3 className={subHeading}>5. Third-Party Content</h3>
+            <p className={`${proseP} mb-4`}>
+              This site displays information from external sources (like TV networks
+              or public APIs). We do not own or guarantee the accuracy of this
+              content.
+            </p>
 
-        <h2 className="text-2xl font-semibold mb-4">
-          7. Limitation of Liability
-        </h2>
-        <p className="mb-4">
-          The site is provided "as is" without warranties of any kind. We are
-          not responsible for any damages arising from your use or inability to
-          use the site.
-        </p>
+            <h3 className={subHeading}>6. Modifications and Availability</h3>
+            <p className={`${proseP} mb-4`}>
+              We reserve the right to change or remove features at any time without
+              notice. We do not guarantee the site will always be available or
+              error-free.
+            </p>
 
-        <h2 className="text-2xl font-semibold mb-4">8. Termination</h2>
-        <p className="mb-8">
-          We reserve the right to terminate or suspend your account if you
-          violate these Terms or misuse the site.
-        </p>
-      </section>
+            <h3 className={subHeading}>7. Limitation of Liability</h3>
+            <p className={`${proseP} mb-4`}>
+              The site is provided "as is" without warranties of any kind. We are
+              not responsible for any damages arising from your use or inability to
+              use the site.
+            </p>
 
-      <hr className="my-12 border-gray-300" />
+            <h3 className={subHeading}>8. Termination</h3>
+            <p className={`${proseP} mb-8`}>
+              We reserve the right to terminate or suspend your account if you
+              violate these Terms or misuse the site.
+            </p>
+          </section>
 
-      <section id="privacy-policy">
-        <h1 className="text-4xl font-bold mb-4 text-slate-950">
-          Privacy Policy
-        </h1>
-        <p className="text-sm text-gray-500 mb-8">
-          <strong>Effective Date:</strong> 2024-10-01
-        </p>
+          <hr className="my-12 border-line" />
 
-        <h2 className="text-2xl font-semibold mb-4">
-          1. Information We Collect
-        </h2>
-        <ul className="list-disc list-inside mb-4">
-          <li>
-            We use <strong>Clerk</strong> for authentication and user
-            management. When you sign up or log in, Clerk may collect your email
-            and other personal information to manage your account.
-          </li>
-          <li>
-            <strong>Without an Account:</strong> We do not collect personal
-            information unless you create an account.
-          </li>
-          <li>
-            <strong>With an Account:</strong> We collect your email to manage
-            personalized features (like tracking shows or sending
-            notifications).
-          </li>
-          <li>
-            <strong>Cookies:</strong> We use cookies for login sessions and to
-            enhance your experience.
-          </li>
-          <li>
-            <strong>Log Data:</strong> We may collect IP addresses and browser
-            data to monitor site performance and troubleshoot issues.
-          </li>
-        </ul>
+          <section id="privacy-policy">
+            <h2 className={sectionTitle}>Privacy Policy</h2>
+            <p className={effectiveDate}>
+              <strong>Effective Date:</strong> 2024-10-01
+            </p>
 
-        <h2 className="text-2xl font-semibold mb-4">
-          2. How We Use Your Information
-        </h2>
-        <ul className="list-disc list-inside mb-4">
-          <li>To authenticate users through Clerk's services.</li>
-          <li>
-            To manage personalized features (like saving comics you want to be
-            notified about).
-          </li>
-          <li>
-            To communicate with you about important updates or account-related
-            issues.
-          </li>
-          <li>To analyze site performance and improve functionality.</li>
-        </ul>
+            <h3 className={subHeading}>1. Information We Collect</h3>
+            <ul className={`${proseList} mb-4`}>
+              <li>
+                We use <strong>Clerk</strong> for authentication and user
+                management. When you sign up or log in, Clerk may collect your email
+                and other personal information to manage your account.
+              </li>
+              <li>
+                <strong>Without an Account:</strong> We do not collect personal
+                information unless you create an account.
+              </li>
+              <li>
+                <strong>With an Account:</strong> We collect your email to manage
+                personalized features (like tracking shows or sending
+                notifications).
+              </li>
+              <li>
+                <strong>Cookies:</strong> We use cookies for login sessions and to
+                enhance your experience.
+              </li>
+              <li>
+                <strong>Log Data:</strong> We may collect IP addresses and browser
+                data to monitor site performance and troubleshoot issues.
+              </li>
+            </ul>
 
-        <h2 className="text-2xl font-semibold mb-4">
-          3. Sharing of Information
-        </h2>
-        <ul className="list-disc list-inside mb-4">
-          <li>
-            We use <strong>Clerk</strong> for authentication and user
-            management. Clerk may collect and store your information according
-            to their{" "}
-            <a
-              href="https://clerk.dev/privacy"
-              target="_blank"
-              className="text-blue-500 underline"
-            >
-              privacy policy
-            </a>
-            .
-          </li>
-          <li>
-            We do not sell or share your personal information with third
-            parties.
-          </li>
-          <li>
-            We may use <strong>third-party services</strong> (e.g., hosting,
-            analytics) that may collect non-personal data.
-          </li>
-          <li>
-            We use{" "}
-            <a
-              href="https://www.buymeacoffee.com/"
-              target="_blank"
-              className="text-blue-500 underline"
-            >
-              Buy Me a Coffee
-            </a>{" "}
-            for optional donations. Please refer to their
-            <a
-              href="https://www.buymeacoffee.com/privacy-policy"
-              className="text-blue-500 underline"
-            >
-              privacy policy
-            </a>{" "}
-            to understand how your data is handled during transactions.
-          </li>
-        </ul>
+            <h3 className={subHeading}>2. How We Use Your Information</h3>
+            <ul className={`${proseList} mb-4`}>
+              <li>To authenticate users through Clerk's services.</li>
+              <li>
+                To manage personalized features (like saving comics you want to be
+                notified about).
+              </li>
+              <li>
+                To communicate with you about important updates or account-related
+                issues.
+              </li>
+              <li>To analyze site performance and improve functionality.</li>
+            </ul>
 
-        <h2 className="text-2xl font-semibold mb-4">4. Data Security</h2>
-        <p className="mb-4">
-          We use reasonable security measures to protect your data, but no
-          service is entirely secure.
-        </p>
+            <h3 className={subHeading}>3. Sharing of Information</h3>
+            <ul className={`${proseList} mb-4`}>
+              <li>
+                We use <strong>Clerk</strong> for authentication and user
+                management. Clerk may collect and store your information according
+                to their{" "}
+                <Link
+                  href="https://clerk.dev/privacy"
+                  target="_blank"
+                  variant="underline"
+                >
+                  privacy policy
+                </Link>
+                .
+              </li>
+              <li>
+                We do not sell or share your personal information with third
+                parties.
+              </li>
+              <li>
+                We may use <strong>third-party services</strong> (e.g., hosting,
+                analytics) that may collect non-personal data.
+              </li>
+              <li>
+                We use{" "}
+                <Link
+                  href="https://www.buymeacoffee.com/"
+                  target="_blank"
+                  variant="underline"
+                >
+                  Buy Me a Coffee
+                </Link>{" "}
+                for optional donations. Please refer to their
+                <Link
+                  href="https://www.buymeacoffee.com/privacy-policy"
+                  variant="underline"
+                >
+                  privacy policy
+                </Link>{" "}
+                to understand how your data is handled during transactions.
+              </li>
+            </ul>
 
-        <h2 className="text-2xl font-semibold mb-4">
-          5. Your Rights and Choices
-        </h2>
-        <ul className="list-disc list-inside mb-4">
-          <li>
-            You can delete your account at any time on your{" "}
-            <a href="/profile" className="text-blue-500 underline">
-              profile
-            </a>{" "}
-            page.
-          </li>
-          <li>
-            You can disable cookies in your browser settings, though this may
-            affect certain features.
-          </li>
-        </ul>
+            <h3 className={subHeading}>4. Data Security</h3>
+            <p className={`${proseP} mb-4`}>
+              We use reasonable security measures to protect your data, but no
+              service is entirely secure.
+            </p>
 
-        <h2 className="text-2xl font-semibold mb-4">
-          6. Children&apos;s Privacy
-        </h2>
-        <p className="mb-4">
-          This site is not intended for users under 13, and we do not knowingly
-          collect data from children.
-        </p>
+            <h3 className={subHeading}>5. Your Rights and Choices</h3>
+            <ul className={`${proseList} mb-4`}>
+              <li>
+                You can delete your account at any time on your{" "}
+                <Link href="/profile" variant="underline">
+                  profile
+                </Link>{" "}
+                page.
+              </li>
+              <li>
+                You can disable cookies in your browser settings, though this may
+                affect certain features.
+              </li>
+            </ul>
 
-        <h2 className="text-2xl font-semibold mb-4">
-          7. Changes to the Policy
-        </h2>
-        <p className="mb-8">
-          We may update this policy occasionally. If there are significant
-          changes, we will notify you via email or on the site.
-        </p>
-      </section>
+            <h3 className={subHeading}>6. Children&apos;s Privacy</h3>
+            <p className={`${proseP} mb-4`}>
+              This site is not intended for users under 13, and we do not knowingly
+              collect data from children.
+            </p>
 
-      <hr className="my-12 border-gray-300" />
+            <h3 className={subHeading}>7. Changes to the Policy</h3>
+            <p className={`${proseP} mb-8`}>
+              We may update this policy occasionally. If there are significant
+              changes, we will notify you via email or on the site.
+            </p>
+          </section>
 
-      <section id="author-message">
-        <h2 className="text-2xl font-semibold mb-4">
-          Message from the Developer:
-        </h2>
-        <ul className="list-disc list-inside">
-          <li>I built this website to fulfill my own needs.</li>
-          <li>
-            You don't have to use this website to reserve tickets. I provide
-            links so you can reserve directly through{" "}
-            <a
-              href="https://comedycellar.com"
-              target="_blank"
-              className="text-blue-500 underline"
-            >
-              Comedy Cellar
-            </a>
-            .
-          </li>
-          <li>
-            Authentication and user management are handled by{" "}
-            <a
-              href="https://clerk.com"
-              target="_blank"
-              className="text-blue-500 underline"
-            >
-              Clerk
-            </a>
-            . I don't collect or manage any personal data. However, to offer
-            personalized features, I need to identify users. You can delete your
-            account at any time for any reason. When you delete your account,
-            all associated data, including personalized settings, will also be
-            deleted and cannot be recovered.
-          </li>
-        </ul>
-      </section>
+          <hr className="my-12 border-line" />
 
-      {/* <section id="contact">
-        <h2 className="text-2xl font-semibold mb-4">Contact Us</h2>
-        <p>
-          If you have any questions about these Terms or our Privacy Policy,
-          contact us at
-          <strong>[email here] </strong>.
-        </p>
-      </section> */}
+          <section id="author-message">
+            <h2 className={sectionTitle}>Message from the Developer:</h2>
+            <ul className={proseList}>
+              <li>I built this website to fulfill my own needs.</li>
+              <li>
+                You don't have to use this website to reserve tickets. I provide
+                links so you can reserve directly through{" "}
+                <Link
+                  href="https://comedycellar.com"
+                  target="_blank"
+                  variant="underline"
+                >
+                  Comedy Cellar
+                </Link>
+                .
+              </li>
+              <li>
+                Authentication and user management are handled by{" "}
+                <Link href="https://clerk.com" target="_blank" variant="underline">
+                  Clerk
+                </Link>
+                . I don't collect or manage any personal data. However, to offer
+                personalized features, I need to identify users. You can delete your
+                account at any time for any reason. When you delete your account,
+                all associated data, including personalized settings, will also be
+                deleted and cannot be recovered.
+              </li>
+            </ul>
+          </section>
+
+          {/* <section id="contact">
+            <h2 className="text-2xl font-semibold mb-4">Contact Us</h2>
+            <p>
+              If you have any questions about these Terms or our Privacy Policy,
+              contact us at
+              <strong>[email here] </strong>.
+            </p>
+          </section> */}
+        </CardBody>
+      </Card>
     </div>
   );
 }

--- a/packages/frontend/src/pages/Updates/index.tsx
+++ b/packages/frontend/src/pages/Updates/index.tsx
@@ -1,28 +1,68 @@
+import clsx from "clsx";
+
+import { PageHeader } from "../../components/ui/PageHeader";
+import { Pill } from "../../components/ui/Pill";
 import { updates } from "./data";
 
 export default function Updates() {
-  return (
-    <div className="mt-10 max-w-4xl mx-auto p-4 bg-white shadow-sm ring-1 ring-gray-200 rounded-lg">
-      <div className="text-center mb-12">
-        <h1 className="text-4xl font-bold mb-4 text-slate-950">What's New</h1>
-        <p className="text-lg text-gray-600 max-w-2xl mx-auto">
-          Stay up to date with the latest features and improvements
-        </p>
-      </div>
+  // data.ts carries no `isNew` flag, so the marquee "New" accent is derived
+  // purely for display from the newest date group (does not alter data wiring).
+  const newestDate = updates[0]?.date;
 
-      {/* Updates */}
-      <div className="space-y-8">
-        {updates.map((update, index) => (
-          <div key={index} className="border-l-4 border-primary pl-4 py-4">
-            <div className="flex items-center mb-2">
-              <span className="text-sm text-gray-500">{update.date}</span>
-            </div>
-            <h3 className="text-xl font-semibold mb-2 text-slate-950">
-              {update.title}
-            </h3>
-            <p className="text-gray-700">{update.text}</p>
-          </div>
-        ))}
+  return (
+    <div className="min-h-screen bg-bg text-text">
+      <div className="mx-auto max-w-[760px] px-6 pt-9 pb-[70px]">
+        <PageHeader
+          eyebrow="Changelog"
+          title="What's New"
+          subline="Fresh features and fixes from backstage."
+        />
+
+        {/* timeline */}
+        <div className="relative mt-9 pl-[34px]">
+          {/* dashed left rail */}
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute left-[6px] top-[6px] bottom-[6px] border-l-2 border-dashed border-line"
+          />
+
+          {updates.map((update, index) => {
+            const isNew = update.date === newestDate;
+            return (
+              <div key={index} className="relative mb-[18px]">
+                {/* node dot on the rail */}
+                <div
+                  aria-hidden="true"
+                  className={clsx(
+                    "absolute left-[-34px] top-4 size-[0.875rem] rounded-full border-hair border-line",
+                    isNew ? "bg-brand" : "bg-surface",
+                  )}
+                />
+
+                <div className="rounded-xl border-hair border-line bg-surface px-5 py-4 shadow-block transition-all duration-150 ease-out hover:-translate-x-px hover:-translate-y-px hover:shadow-block-lg">
+                  <div className="mb-1.5 flex items-center gap-2.5">
+                    <span className="font-mono text-meta uppercase tracking-wider text-gold">
+                      {update.date}
+                    </span>
+                    {isNew ? (
+                      <Pill className="border-brand bg-brand text-brand-fg">
+                        New
+                      </Pill>
+                    ) : null}
+                  </div>
+
+                  <h3 className="mb-1.5 font-sans text-lg font-extrabold text-text">
+                    {update.title}
+                  </h3>
+
+                  <p className="font-sans text-caption leading-relaxed text-muted">
+                    {update.text}
+                  </p>
+                </div>
+              </div>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -11,9 +11,11 @@
     "jsx": "react-jsx",
     "jsxImportSource": "preact",
     "skipLibCheck": true,
+    "baseUrl": ".",
     "paths": {
       "react": ["./node_modules/preact/compat/"],
-      "react-dom": ["./node_modules/preact/compat/"]
+      "react-dom": ["./node_modules/preact/compat/"],
+      "@/*": ["./src/*"]
     }
   },
   "include": ["node_modules/vite/client.d.ts", "**/*"]

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite";
 import preact from "@preact/preset-vite";
 import { ViteEjsPlugin } from "./vitePluginEjs";
@@ -5,6 +6,11 @@ import { ViteEjsPlugin } from "./vitePluginEjs";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [preact(), ViteEjsPlugin()],
+  resolve: {
+    alias: [
+      { find: "@", replacement: fileURLToPath(new URL("./src", import.meta.url)) },
+    ],
+  },
   define: {
     // By default, Vite doesn't include shims for NodeJS/
     // necessary for segment analytics lib to work


### PR DESCRIPTION
Restyles every screen and its single-consumer components in place onto the vintage-marquee tokens and Wave 0B-0D ui kit, keeping routes and data wiring intact: Home (Calendar, CalendarButton, Event, new CompactRow + types, EventLoader, Act/Availablity), Comics (SearchInput, ComicItem, ShowCount heat legend), Comic detail (banner, upcoming shows, notification button, AlongsideComics), Reservations (form Helpers, ShowDetails ticket stub, Disclaimer, error/success states), Profile (index, settings, tabs), Auth (PageWrapper, SignIn, SignUp — Clerk widgets kept, chrome restyled), Updates timeline, Terms/NotFound, and the shared Input primitive. Also updates the Gallery preview page for SegmentedToggle's generic prop usage. Frontend builds clean (`vite build`).