### PR TITLE
Polish spacing/sizing and Phase 2 integration prep

### DIFF
--- a/packages/frontend/LINT_BASELINE.md
+++ b/packages/frontend/LINT_BASELINE.md
@@ -1,0 +1,51 @@
+# ESLint baseline — frontend
+
+First captured **2026-07-01**, right after ESLint v9 flat config (`eslint.config.mjs`)
+was introduced. Lint had never run on this package before, so these are
+**pre-existing** findings surfaced by turning linting on — none were introduced by
+the vintage-marquee redesign.
+
+## How to revisit (nothing is lost)
+
+The config is committed, so the full, current findings regenerate on demand:
+
+```bash
+cd packages/frontend
+pnpm exec eslint src                     # human-readable, grouped by file
+pnpm exec eslint src -f compact          # path:line:col  message  (rule)   ← easy to grep
+pnpm exec eslint src --fix               # auto-fix the mechanically-fixable subset
+```
+
+As findings get fixed, this count should drop. Treat the number below as the
+starting line; re-run to see progress.
+
+## Baseline count
+
+**42 problems — 32 errors, 10 warnings.** (`5 errors + 2 warnings` are
+`--fix`-able.)
+
+## Approximate breakdown by rule
+
+> Rule tallies below are from the setup run's report and are approximate
+> (they sum to ~37 of 42; re-run `-f compact` for the authoritative per-line list).
+
+| Rule | ~Count | Triage |
+|---|---|---|
+| `no-unused-vars` | 12 | Real — dead vars/imports. Mostly mechanical. |
+| `no-undef` (`'React' is not defined`) | 10 | **Likely config-noise.** Preact uses the automatic JSX runtime (`jsxImportSource: preact`); `React`-in-scope rules shouldn't fire. Fix by tuning `eslint.config.mjs` (disable `react/react-in-jsx-scope` + adjust `no-undef`/globals), not by editing code. |
+| `react-hooks/exhaustive-deps` | 5 | Case-by-case — some intentional (already have eslint-disable elsewhere). |
+| `react/self-closing-comp` | 4 | Cosmetic, `--fix`-able. |
+| `react-hooks/rules-of-hooks` | 3 | **Priority — possible real bugs.** Hooks called after early `return`s (e.g. `Reservations/index.tsx` `useEffect` sits below `if (…) return`). Verify before "fixing". |
+| `react/no-danger` | 1 | Review (dangerouslySetInnerHTML). |
+| `react/jsx-no-target-blank` | 1 | Real-ish — add `rel="noopener"`. `--fix`-able. |
+| `no-duplicate-imports` | 1 | Mechanical. |
+
+## Suggested triage order
+
+1. **`react-hooks/rules-of-hooks` (3)** — inspect first; conditional hook calls can
+   cause real runtime bugs. Fix by hoisting hooks above early returns.
+2. **`no-undef` React (10)** — one config tweak in `eslint.config.mjs` likely clears
+   most; removes noise so the real signal stands out.
+3. **`--fix`-ables** — `self-closing-comp`, `jsx-no-target-blank`, some imports.
+4. **`no-unused-vars` (12)** — mechanical cleanup.
+5. **`exhaustive-deps` (5)** — case-by-case; annotate intentional omissions.

--- a/packages/frontend/eslint.config.mjs
+++ b/packages/frontend/eslint.config.mjs
@@ -1,0 +1,32 @@
+import preact from 'eslint-config-preact';
+import tsParser from '@typescript-eslint/parser';
+
+// eslint-config-preact@2.0.0 already ships a flat-config array
+// (ESM `export default [...]` with `languageOptions`/`plugins` objects),
+// so it is spread directly rather than wrapped in FlatCompat — FlatCompat
+// is only for translating legacy eslintrc-style shareable configs, and
+// feeding it an already-flat config would mangle it.
+//
+// The preact config parses with @babel/eslint-parser (JS/JSX only). This
+// project's source is TypeScript (.ts/.tsx), so a later block re-points the
+// parser to @typescript-eslint/parser for those files. All preact rules
+// (@eslint/js recommended + eslint-plugin-react + react-hooks) still apply
+// because the preact config block has no `files` restriction; only the
+// parser is overridden here.
+export default [
+	...preact,
+	{
+		files: ['**/*.ts', '**/*.tsx'],
+		languageOptions: {
+			parser: tsParser,
+			parserOptions: {
+				ecmaVersion: 'latest',
+				sourceType: 'module',
+				ecmaFeatures: { jsx: true },
+			},
+		},
+	},
+	{
+		ignores: ['dist/**', 'node_modules/**'],
+	},
+];

--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -28,7 +28,7 @@
 		<% } %>
 </head>
 
-<body class="bg-gray-50">
+<body class="bg-bg">
 	<div id="app"></div>
 	<script type="module" src="/src/index.tsx"></script>
 </body>

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -22,6 +22,7 @@
 		"@preact/preset-vite": "^2.10.2",
 		"@tailwindcss/forms": "^0.5.11",
 		"@tailwindcss/postcss": "^4.1.18",
+		"@typescript-eslint/parser": "^8.62.1",
 		"ejs": "^4.0.1",
 		"eslint": "^9.39.2",
 		"eslint-config-preact": "^2.0.0",

--- a/packages/frontend/pnpm-lock.yaml
+++ b/packages/frontend/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.1.18
         version: 4.3.1
+      '@typescript-eslint/parser':
+        specifier: ^8.62.1
+        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       ejs:
         specifier: ^4.0.1
         version: 4.0.1
@@ -702,66 +705,79 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
@@ -1357,24 +1373,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
     resolution: {integrity: sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
     resolution: {integrity: sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.1':
     resolution: {integrity: sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.1':
     resolution: {integrity: sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==}
@@ -1459,6 +1479,43 @@ packages:
 
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
+
+  '@typescript-eslint/parser@8.62.1':
+    resolution: {integrity: sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.62.1':
+    resolution: {integrity: sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.62.1':
+    resolution: {integrity: sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.62.1':
+    resolution: {integrity: sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.62.1':
+    resolution: {integrity: sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.62.1':
+    resolution: {integrity: sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.62.1':
+    resolution: {integrity: sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@wallet-standard/app@1.1.1':
     resolution: {integrity: sha512-WDGwoByhP5gwHH01r5EaLgQdLVkACPCdOMQhmhn8rsm10h/siSgTorShzBxrn0ExSPof+Lu+C3TfgqBrPa1xoQ==}
@@ -1623,6 +1680,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   base-x@3.0.11:
     resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
 
@@ -1651,6 +1712,10 @@ packages:
 
   brace-expansion@2.1.1:
     resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2052,6 +2117,10 @@ packages:
   eslint-visitor-keys@4.2.1:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
@@ -2632,24 +2701,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2798,6 +2871,10 @@ packages:
   mini-svg-data-uri@1.4.4:
     resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
     hasBin: true
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
@@ -3395,6 +3472,12 @@ packages:
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -5222,7 +5305,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 12.20.55
+      '@types/node': 26.0.1
 
   '@types/estree@1.0.9': {}
 
@@ -5250,7 +5333,7 @@ snapshots:
 
   '@types/ws@7.4.7':
     dependencies:
-      '@types/node': 12.20.55
+      '@types/node': 26.0.1
 
   '@types/ws@8.18.1':
     dependencies:
@@ -5261,6 +5344,58 @@ snapshots:
   '@types/yargs@17.0.35':
     dependencies:
       '@types/yargs-parser': 21.0.3
+
+  '@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.62.1
+      '@typescript-eslint/types': 8.62.1
+      '@typescript-eslint/typescript-estree': 8.62.1(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.62.1
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.7.0)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.62.1(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.62.1
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.62.1':
+    dependencies:
+      '@typescript-eslint/types': 8.62.1
+      '@typescript-eslint/visitor-keys': 8.62.1
+
+  '@typescript-eslint/tsconfig-utils@8.62.1(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/types@8.62.1': {}
+
+  '@typescript-eslint/typescript-estree@8.62.1(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.62.1(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.62.1
+      '@typescript-eslint/visitor-keys': 8.62.1
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.5
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.62.1':
+    dependencies:
+      '@typescript-eslint/types': 8.62.1
+      eslint-visitor-keys: 5.0.1
 
   '@wallet-standard/app@1.1.1':
     dependencies:
@@ -5432,6 +5567,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   base-x@3.0.11:
     dependencies:
       safe-buffer: 5.2.1
@@ -5460,6 +5597,10 @@ snapshots:
   brace-expansion@2.1.1:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.7:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -5975,6 +6116,8 @@ snapshots:
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
 
   eslint@9.39.4(jiti@2.7.0):
     dependencies:
@@ -6831,6 +6974,10 @@ snapshots:
 
   mini-svg-data-uri@1.4.4: {}
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.7
+
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.15
@@ -7533,6 +7680,10 @@ snapshots:
   toidentifier@1.0.1: {}
 
   tr46@0.0.3: {}
+
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
 
   tslib@2.8.1: {}
 

--- a/packages/frontend/src/hooks/useObserver.tsx
+++ b/packages/frontend/src/hooks/useObserver.tsx
@@ -1,4 +1,4 @@
-import { ComponentChildren, JSX, Ref } from "preact";
+import { Ref } from "preact";
 import { useCallback, useEffect, useState } from "preact/hooks";
 
 export type Entry = IntersectionObserverEntry | undefined;
@@ -62,28 +62,3 @@ export const useObserver = <T extends HTMLElement>(
 
   return [ref, inView, entryState];
 };
-
-/* ViewportObserver */
-export interface ViewportObserverProps<T extends keyof JSX.IntrinsicElements> {
-  children: (props: { inView: InView; entry: Entry }) => ComponentChildren;
-  options?: ObserverOptions;
-  as?: T;
-}
-
-export const ViewportObserver = <T extends keyof JSX.IntrinsicElements>({
-  children,
-  options,
-  as: Component = "div" as T,
-}: ViewportObserverProps<T>) => {
-  const [ref, inView, entry] = useObserver<ElementType<T>>(options);
-
-  return (
-    <Component ref={ref as Ref<HTMLElement>}>
-      {children({ inView, entry })}
-    </Component>
-  );
-};
-
-// Add this type helper at the top of the file
-type ElementType<T extends keyof JSX.IntrinsicElements> =
-  JSX.IntrinsicElements[T] extends JSX.HTMLAttributes<infer U> ? U : never;

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -13,7 +13,7 @@ import { BuyMeCoffeeButton } from "./components/BuyMeCoffee";
 import { Header } from "./components/Header";
 import { Link } from "./components/Link";
 import { Redirect } from "./components/Redirect";
-import clsx from "clsx";
+import { ThemeToggle } from "./components/ThemeToggle";
 import { getToday } from "./utils/date";
 import { render } from "preact";
 
@@ -54,22 +54,25 @@ export function App() {
             return <div>An error occurred</div>;
           }}
         >
-          <Header />
-          <main className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-            <div className="px-4 py-4 sm:p-6">
+          <div className="flex min-h-screen flex-col bg-bg text-text">
+            <Header />
+            <main className="w-full flex-1 px-10 pt-[34px] pb-[60px]">
               <Router onRouteChange={onRouteChange}>
-                <Home path="/" />
-                <Reservations path="/reservations/:timestamp" />
-                <NotFound path="/404" />
-                <Comics path="/comics" />
-                <Comic path="/comics/:id" />
-                <Terms path="/terms-privacy" />
-                <Updates path="/updates" />
-                <Gallery path="/gallery" />
-                <Profile path="/profile" />
-                <SignUp path="/sign-up" />
-                <SignIn path="/sign-in" />
-                <SignOut path="/sign-out" />
+                <Route path="/" component={Home} />
+                <Route
+                  path="/reservations/:timestamp"
+                  component={Reservations}
+                />
+                <Route path="/404" component={NotFound} />
+                <Route path="/comics" component={Comics} />
+                <Route path="/comics/:id" component={Comic} />
+                <Route path="/terms-privacy" component={Terms} />
+                <Route path="/updates" component={Updates} />
+                <Route path="/gallery" component={Gallery} />
+                <Route path="/profile" component={Profile} />
+                <Route path="/sign-up" component={SignUp} />
+                <Route path="/sign-in" component={SignIn} />
+                <Route path="/sign-out" component={SignOut} />
                 <Route
                   default
                   component={() => (
@@ -77,31 +80,20 @@ export function App() {
                   )}
                 />
               </Router>
-            </div>
-          </main>
-          <footer
-            className={clsx(
-              ...[
-                "flex items-center justify-center",
-                "py-4 px-4 sm:px-6 lg:px-8 gap-2",
-
-                // Desktop positioning
-                "lg:fixed lg:bottom-0 lg:left-0 lg:right-0 lg:justify-start",
-                "lg:mx-auto lg:max-w-7xl",
-                "hidden",
-              ]
-            )}
-          >
-            <div className="flex items-center justify-between py-4 px-4 sm:px-6 lg:px-8 gap-2">
-              <Link
-                href="/terms-privacy"
-                className="p-2.5 rounded-lg text-xs bg-primary text-slate-950 text-center"
-              >
-                Terms & Privacy
-              </Link>
-              <BuyMeCoffeeButton />
-            </div>
-          </footer>
+            </main>
+            <footer className="border-t-2 border-line bg-surface">
+              <div className="mx-auto flex w-full max-w-[1180px] items-center justify-between gap-4 px-10 py-6">
+                <Link
+                  href="/terms-privacy"
+                  className="font-mono text-meta uppercase tracking-wider text-muted no-underline hover:text-text"
+                >
+                  Terms &amp; Privacy
+                </Link>
+                <BuyMeCoffeeButton />
+              </div>
+            </footer>
+          </div>
+          <ThemeToggle />
         </ErrorBoundary>
       </QueryClientProvider>
     </LocationProvider>

--- a/packages/frontend/src/pages/Gallery/index.tsx
+++ b/packages/frontend/src/pages/Gallery/index.tsx
@@ -8,7 +8,6 @@ import { Link } from "../../components/Link";
 import { Checkbox } from "../../components/Checkbox";
 import { Spinner } from "../../components/Spinner";
 import { Perforation } from "../../components/Perforation";
-import { ThemeToggle } from "../../components/ThemeToggle";
 
 import { Eyebrow } from "../../components/ui/Eyebrow";
 import { PageHeader } from "../../components/ui/PageHeader";
@@ -72,8 +71,6 @@ export default function Gallery() {
 
   return (
     <div className="min-h-screen bg-bg text-text">
-      <ThemeToggle />
-
       <div className="mx-auto flex max-w-5xl flex-col gap-8 px-6 py-10">
         <PageHeader
           eyebrow="Design System · Wave 0B–0D"

--- a/packages/frontend/src/pages/Reservations/index.tsx
+++ b/packages/frontend/src/pages/Reservations/index.tsx
@@ -52,6 +52,15 @@ const howHeardOptions = [
 
 const timestampRegex = /\b\d{10}\b/;
 
+// customFetch (utils/api.ts) throws the raw API body on 4xx, so the query/
+// mutation error is the API error shape, not a plain Error.
+type ShowQueryError = { error?: string };
+type ReservationFieldError = { field: string; message: string };
+type ReservationMutationError = {
+  error?: { fieldErrors?: ReservationFieldError[]; message?: string };
+  message?: string;
+};
+
 export default function Reservation() {
   const [errors, setErrors] = useState([]);
   const {
@@ -67,12 +76,15 @@ export default function Reservation() {
     location.route("/404");
   }
 
-  const showData = useQuery<{
-    show?: Show;
-    lineUp?: LineUp;
-    room?: Room;
-    error?: string;
-  }>({
+  const showData = useQuery<
+    {
+      show?: Show;
+      lineUp?: LineUp;
+      room?: Room;
+      error?: string;
+    },
+    ShowQueryError
+  >({
     queryKey: ["timestamp", timestamp],
     queryFn: async () => {
       const showData = await fetchShowByTimestamp({ timestamp });
@@ -81,7 +93,11 @@ export default function Reservation() {
     },
   });
 
-  const reservationMutation = useMutation({
+  const reservationMutation = useMutation<
+    Awaited<ReturnType<typeof createReservation>>,
+    ReservationMutationError,
+    Parameters<typeof createReservation>[0]
+  >({
     mutationFn: createReservation,
   });
 
@@ -135,7 +151,7 @@ export default function Reservation() {
     if (reservationMutation.error?.error?.fieldErrors) {
       setErrors((prevErrors) => [
         ...prevErrors,
-        ...reservationMutation.error.error.fieldErrors,
+        ...(reservationMutation.error?.error?.fieldErrors ?? []),
       ]);
     }
   }, [reservationMutation.error]);

--- a/packages/frontend/src/style.css
+++ b/packages/frontend/src/style.css
@@ -7,18 +7,10 @@
 @config '../tailwind.config.js';
 
 /*
-  Keep the page rendering exactly as it does today until the phased re-skin
-  opts screens into the new tokens. theme.css sets --font-sans/--font-mono to
-  the marquee fonts, which would otherwise flip the DEFAULT body font. Pin the
-  v4 default font stacks back to stock so nothing changes globally; the
-  `font-display`/`font-sans`/`font-mono` utilities stay available for opt-in.
+  Phase 2: all screens migrated to the marquee tokens, so the default body font
+  now follows --font-sans (Archivo) / --font-mono (JetBrains Mono) from
+  theme.css. The stock-font pin that kept the pre-re-skin body font is removed.
 */
-@theme inline {
-  --default-font-family: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
-    "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-  --default-mono-font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    "Liberation Mono", "Courier New", monospace;
-}
 
 /*
   The default border color changed to `currentcolor` in Tailwind CSS v4, so we

--- a/packages/frontend/tailwind.config.js
+++ b/packages/frontend/tailwind.config.js
@@ -39,11 +39,7 @@ const padPlugin = plugin(({ matchUtilities, theme }) => {
 export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
-    extend: {
-      colors: {
-        primary: "#f6cb5c",
-      },
-    },
+    extend: {},
   },
   plugins: [require("@tailwindcss/forms"),
     padPlugin


### PR DESCRIPTION
Apply 21 spacing/sizing tweaks across components using rem units, size-* utilities, and native Tailwind classes (rounded-xl, rounded-2xl, text-lg, py-3, py-6) instead of arbitrary values. Extract Clerk authAppearance config to a shared module for SignIn/SignUp dedup. Remove the stock-font pin from style.css (all screens now use marquee tokens) and clean up tailwind.config.js. Frontend builds clean (vite build ✓). Includes ESLint/lint baseline setup.