### PR TITLE
Theme toggle styling + compact UI fixes

### DIFF
--- a/packages/frontend/src/components/Calendar.tsx
+++ b/packages/frontend/src/components/Calendar.tsx
@@ -133,7 +133,7 @@ export function Calendar({ value, onChange }) {
   const weekdayInitials = ["S", "M", "T", "W", "T", "F", "S"];
 
   return (
-    <div className="border-hair border-line rounded-panel bg-surface p-[1.125rem] shadow-block-md">
+    <div className="calendar-dark-shadow border-hair border-line rounded-panel bg-surface p-[1.125rem] shadow-block-md">
       <div className="mb-3.5 flex items-center justify-between">
         <button
           type="button"

--- a/packages/frontend/src/components/CalendarButton.tsx
+++ b/packages/frontend/src/components/CalendarButton.tsx
@@ -37,8 +37,8 @@ export function CalendarButton({ day, onClick }: CalendarButtonProps) {
         aria-hidden="true"
         className={clsx(
           "absolute size-8 rounded-full transition-colors",
-          isToday && "border-hair border-line bg-brand",
-          isSelected && !isToday && "bg-solid",
+          isSelected && "bg-solid",
+          isToday && !isSelected && "border-2 border-solid",
           !isToday &&
             !isSelected &&
             "group-hover:bg-track group-focus-visible:bg-track"
@@ -48,8 +48,8 @@ export function CalendarButton({ day, onClick }: CalendarButtonProps) {
         dateTime={day.date}
         className={clsx(
           "relative font-sans text-[13px] font-semibold",
-          isToday && "text-brand-fg",
-          isSelected && !isToday && "text-solid-fg",
+          isSelected && "text-solid-fg",
+          isToday && !isSelected && "text-text",
           !isToday && !isSelected && isCurrentMonth && "text-text",
           !isToday && !isSelected && !isCurrentMonth && "text-faint"
         )}

--- a/packages/frontend/src/components/Event.tsx
+++ b/packages/frontend/src/components/Event.tsx
@@ -1,8 +1,6 @@
-import { useState } from "preact/hooks";
 import clsx from "clsx";
 import {
   ChevronDownIcon,
-  ChevronUpIcon,
   ArrowTopRightOnSquareIcon,
 } from "@heroicons/react/20/solid";
 
@@ -17,19 +15,34 @@ type EventItemProps = {
   show: Show;
   lineUp: LineUp;
   isLineUpLoading: boolean;
+  isOpen: boolean;
+  onToggle: () => void;
 };
 
 export function Event(props: EventItemProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
-  const { isLineUpLoading } = props;
+  const { isLineUpLoading, isOpen, onToggle } = props;
   const { description, timestamp, reservationUrl } = props.show;
   const { acts } = props.lineUp;
 
   const view = getShowView(props.show);
 
+  const lineupNote = isLineUpLoading
+    ? "…"
+    : acts.length > 0
+      ? `${acts.length} comics`
+      : "lineup TBA";
+  const lineupHeading =
+    acts.length > 0 ? `Tonight's Lineup · ${acts.length} acts` : "Lineup";
+
+  const handleToggle = () => {
+    if (isLineUpLoading) return;
+    onToggle();
+  };
+
   return (
-    <>
-      <article className="group flex overflow-hidden rounded-card border-hair border-line bg-surface shadow-block transition hover:-translate-x-px hover:-translate-y-px hover:shadow-block-lg">
+    <article className="group overflow-hidden rounded-card border-hair border-line bg-surface shadow-block transition hover:-translate-x-px hover:-translate-y-px hover:shadow-block-lg">
+      {/* Clickable header: time stub + body */}
+      <div className="flex cursor-pointer" onClick={handleToggle}>
         {/* Time stub */}
         <div
           className={clsx(
@@ -62,7 +75,7 @@ export function Event(props: EventItemProps) {
         </div>
 
         {/* Body */}
-        <div className="min-w-0 flex-1 px-5 py-4">
+        <div className="min-w-0 flex-1 px-5 py-4 transition-colors hover:bg-track">
           <div className="flex items-start justify-between gap-3">
             <h3
               className="min-w-0 font-sans text-lead font-extrabold text-text"
@@ -70,14 +83,8 @@ export function Event(props: EventItemProps) {
             >
               {view.title}
             </h3>
-            <StatusPill status={view.status} className="shrink-0" />
-          </div>
-
-          <div className="mb-3 mt-2.5 flex items-center gap-2">
-            <p className="min-w-0 truncate font-mono text-meta text-muted">
-              {view.venue} <span className="text-faint">·</span> {view.capLabel}
-            </p>
-            <div className="ml-auto flex shrink-0 items-center gap-1.5">
+            <div className="flex shrink-0 items-center gap-2.5">
+              <StatusPill status={view.status} className="shrink-0" />
               {view.reservable && (
                 <Link
                   href={reservationUrl}
@@ -85,6 +92,7 @@ export function Event(props: EventItemProps) {
                   rel="noreferrer noopener"
                   aria-label="Open reservation page in a new tab"
                   variant="plain"
+                  onClick={(e) => e.stopPropagation()}
                   className="grid size-8 place-items-center rounded-full border-hair border-line text-muted no-underline transition hover:bg-track hover:text-text hover:no-underline"
                 >
                   <ArrowTopRightOnSquareIcon
@@ -96,18 +104,30 @@ export function Event(props: EventItemProps) {
               <button
                 type="button"
                 disabled={isLineUpLoading}
-                aria-expanded={isExpanded}
-                aria-label={isExpanded ? "Hide lineup" : "Show lineup"}
-                onClick={() => setIsExpanded(!isExpanded)}
+                aria-expanded={isOpen}
+                aria-label={isOpen ? "Hide lineup" : "Show lineup"}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onToggle();
+                }}
                 className="grid size-8 place-items-center rounded-full border-hair border-line text-muted outline-none transition hover:bg-track hover:text-text disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
               >
-                {isExpanded ? (
-                  <ChevronUpIcon className="size-4" aria-hidden="true" />
-                ) : (
-                  <ChevronDownIcon className="size-4" aria-hidden="true" />
-                )}
+                <ChevronDownIcon
+                  className={clsx(
+                    "size-4 transition-transform",
+                    isOpen && "rotate-180"
+                  )}
+                  aria-hidden="true"
+                />
               </button>
             </div>
+          </div>
+
+          <div className="mb-3 mt-2.5 flex items-center gap-2">
+            <p className="min-w-0 truncate font-mono text-meta text-muted">
+              {view.venue} <span className="text-faint">·</span> {view.capLabel}{" "}
+              <span className="text-faint">·</span> {lineupNote}
+            </p>
           </div>
 
           <div className="flex items-center gap-3.5">
@@ -118,6 +138,7 @@ export function Event(props: EventItemProps) {
               <Link
                 href={`/reservations/${timestamp}`}
                 variant="plain"
+                onClick={(e) => e.stopPropagation()}
                 className="inline-flex shrink-0 items-center rounded-pill bg-solid px-4 py-2 font-sans text-caption font-bold text-solid-fg no-underline transition hover:bg-brand hover:text-brand-fg hover:no-underline"
               >
                 Reserve Tickets &rarr;
@@ -129,30 +150,42 @@ export function Event(props: EventItemProps) {
             )}
           </div>
         </div>
-      </article>
+      </div>
 
-      {isExpanded && (
-        <div className="mt-2.5 rounded-card border-hair border-line bg-surface p-4 shadow-block-sm">
-          <ul role="list" className="divide-y divide-line">
-            {acts.length > 0 ? (
-              acts.map((act, index) => (
+      {/* Fused lineup panel */}
+      {isOpen && (
+        <div className="animate-lineup-in border-t-2 border-dashed border-line bg-bg px-[22px] pb-5 pt-[18px]">
+          <h4 className="mb-3.5 font-mono text-meta uppercase tracking-wider text-gold">
+            {lineupHeading}
+          </h4>
+          {acts.length > 0 ? (
+            <ul role="list">
+              {acts.map((act, index) => (
                 <li
                   key={index}
-                  className="flex gap-x-4 py-3 first:pt-0 last:pb-0"
+                  className="flex items-start gap-3.5 border-b border-track py-[11px] last:border-b-0"
                 >
                   <Act {...act} />
                 </li>
-              ))
-            ) : (
-              <li className="py-1">
-                <h3 className="font-sans text-caption font-semibold text-text">
-                  No acts found for this show
-                </h3>
-              </li>
-            )}
-          </ul>
+              ))}
+            </ul>
+          ) : (
+            <div className="flex items-center gap-3">
+              <span className="grid size-[34px] shrink-0 place-items-center rounded-full border-hair border-dashed border-faint font-sans text-body text-faint">
+                ?
+              </span>
+              <div>
+                <p className="font-sans text-[15px] font-extrabold text-text">
+                  Lineup not announced yet
+                </p>
+                <p className="mt-0.5 font-mono text-[11px] text-faint">
+                  Acts are usually posted the morning of the show.
+                </p>
+              </div>
+            </div>
+          )}
         </div>
       )}
-    </>
+    </article>
   );
 }

--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -32,16 +32,16 @@ export function Header() {
 
   return (
     <>
-      <header className="flex w-full items-center justify-between bg-brand px-5 py-4 sm:px-10">
+      <header className="flex w-full items-center justify-between bg-brand px-3 py-2.5 sm:px-10 sm:py-4">
         <a href="/" className="flex items-baseline">
-          <span className="font-display text-d-md leading-none tracking-tightcap text-ink">
+          <span className="font-display text-d-sm leading-none tracking-tightcap text-ink sm:text-d-md">
             COMEDY CELLAR
           </span>
-          <span className="ml-2.5 font-mono text-eyebrow tracking-mega text-ink/60">
+          <span className="ml-1.5 hidden font-mono text-eyebrow tracking-mega text-ink/60 sm:ml-2.5 sm:inline">
             EST. NYC 1981
           </span>
         </a>
-        <nav className="flex items-center gap-x-6">
+        <nav className="flex items-center gap-x-2 sm:gap-x-6">
           {navLinks.map((item, itemIdx) => {
             const isLast = itemIdx === navLinks.length - 1;
             const isAuthAction = item.name === "Sign In" || item.name === "Sign out";
@@ -52,7 +52,7 @@ export function Header() {
                   key={itemIdx}
                   href={item.href}
                   variant="plain"
-                  className="rounded-pill bg-ink px-4 py-2 font-sans text-sm font-bold text-brand hover:bg-ink/80"
+                  className="rounded-pill bg-ink px-3 py-2 font-sans text-xs font-bold text-brand hover:bg-ink/80 sm:px-4 sm:text-sm"
                 >
                   {item.name}
                 </Link>
@@ -65,7 +65,8 @@ export function Header() {
                 href={item.href}
                 variant="plain"
                 className={clsx(
-                  "font-sans text-body font-medium text-ink opacity-[.78] hover:underline"
+                  "font-sans font-medium text-ink opacity-[.78] hover:underline",
+                  "text-[11px] sm:text-body"
                 )}
               >
                 {item.name}

--- a/packages/frontend/src/components/SearchInput.tsx
+++ b/packages/frontend/src/components/SearchInput.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "preact/hooks";
+import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import clsx from "clsx";
 
 import { Spinner } from "./Spinner";
@@ -51,18 +52,13 @@ export function SearchInput({
   return (
     <div
       className={clsx(
-        "flex items-center gap-3 rounded-pill border-hair border-line bg-bg px-[1.125rem] py-3",
+        "flex items-center gap-3 rounded-pill border-hair border-line bg-bg px-4.5 py-3",
         "focus-within:shadow-[3px_3px_0_var(--color-brand)]",
         disabled && "opacity-60",
         className,
       )}
     >
-      <span
-        aria-hidden="true"
-        className="select-none font-mono text-caption leading-none text-muted"
-      >
-        ⌕
-      </span>
+      <MagnifyingGlassIcon className="size-4 select-none font-mono text-caption leading-none text-muted" />
       <input
         type="text"
         value={inputValue}

--- a/packages/frontend/src/components/ThemeToggle.tsx
+++ b/packages/frontend/src/components/ThemeToggle.tsx
@@ -21,12 +21,34 @@ export const ThemeToggle: FunctionalComponent<ThemeToggleProps> = ({ className }
       className={clsx(
         "fixed bottom-6 right-6 z-50",
         "grid h-11 w-11 place-items-center",
-        "bg-surface border-hair border-line rounded-pill shadow-block",
+        "bg-surface border-hair border-line rounded-pill shadow-block text-text",
         "hover:bg-brand hover:text-brand-fg transition",
         className,
       )}
     >
-      <span aria-hidden="true">{isDark ? "☾" : "☀"}</span>
+      {isDark ? (
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 24 24"
+          className="h-5 w-5"
+          fill="currentColor"
+        >
+          <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8Z" />
+        </svg>
+      ) : (
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 24 24"
+          className="h-5 w-5"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+        >
+          <circle cx="12" cy="12" r="4" />
+          <path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" />
+        </svg>
+      )}
     </button>
   );
 };

--- a/packages/frontend/src/components/ui/Avatar.tsx
+++ b/packages/frontend/src/components/ui/Avatar.tsx
@@ -35,18 +35,46 @@ function getInitials(name: string): string {
 
 export interface AvatarProps {
   name: string;
+  img?: string;
   size?: number;
   className?: string;
 }
 
-export function Avatar({ name, size = 42, className }: AvatarProps) {
+export function Avatar({ name, img, size = 42, className }: AvatarProps) {
   const { bg, fg } = getSwatch(name);
   const initials = getInitials(name);
+
+  if (img) {
+    return (
+      <span
+        className={clsx(
+          "group relative grid shrink-0 place-items-center overflow-hidden rounded-pill border-hair border-line",
+          className,
+        )}
+        style={{ width: size, height: size }}
+      >
+        <img
+          src={img}
+          alt={`${name}'s photo`}
+          loading="lazy"
+          className="h-full w-full object-cover"
+        />
+        {/* Translucent placeholder overlay on hover */}
+        <span
+          aria-hidden="true"
+          className="absolute inset-0 grid place-items-center font-display leading-none opacity-0 transition-opacity duration-150 group-hover:opacity-80"
+          style={{ fontSize: size * 0.4, backgroundColor: bg, color: fg }}
+        >
+          {initials}
+        </span>
+      </span>
+    );
+  }
 
   return (
     <span
       className={clsx(
-        "grid place-items-center shrink-0 rounded-pill border-hair border-line font-display",
+        "grid place-items-center shrink-0 rounded-pill border-hair border-line font-display leading-none",
         className,
       )}
       style={{

--- a/packages/frontend/src/components/ui/Badge.tsx
+++ b/packages/frontend/src/components/ui/Badge.tsx
@@ -1,0 +1,54 @@
+import clsx from "clsx";
+import type { ComponentChildren } from "preact";
+
+/**
+ * Icon component shape — every glyph in the app comes from
+ * `@heroicons/react/20/solid`, which all share this exact type.
+ */
+export type BadgeIcon = typeof import("@heroicons/react/20/solid").CheckCircleIcon;
+
+/** Semantic color intent for a badge. */
+export type BadgeTone =
+  | "neutral"
+  | "success"
+  | "warning"
+  | "danger"
+  | "muted";
+
+const TONE_CLASSES: Record<BadgeTone, string> = {
+  neutral: "text-stub-ink bg-stub border-hair",
+  success: "text-success bg-success-soft border-success dark:text-success-bright",
+  warning: "text-warning bg-warning-soft border-warning",
+  danger: "text-danger bg-danger-soft border-danger",
+  muted: "text-faint border-line",
+};
+
+type BadgeProps = {
+  /** Color intent. Defaults to `neutral`. */
+  tone?: BadgeTone;
+  /** Optional leading glyph (a heroicons 20/solid component). */
+  icon?: BadgeIcon;
+  className?: string;
+  children?: ComponentChildren;
+};
+
+/**
+ * Reusable pill/chip: mono, uppercase, hairline border, tone-colored, with an
+ * optional leading icon. The shared primitive behind `StatusPill` (show
+ * availability) and the comic-notification badges — pass a `tone` + `icon`
+ * rather than restyling from scratch so every chip in the app matches.
+ */
+export function Badge({ tone = "neutral", icon: Icon, className, children }: BadgeProps) {
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center gap-1 rounded-pill border-hair px-2 py-0.5 font-mono text-meta uppercase tracking-wider",
+        TONE_CLASSES[tone],
+        className,
+      )}
+    >
+      {Icon && <Icon className="size-3.5 shrink-0" aria-hidden="true" />}
+      {children}
+    </span>
+  );
+}

--- a/packages/frontend/src/components/ui/StatusPill.tsx
+++ b/packages/frontend/src/components/ui/StatusPill.tsx
@@ -1,4 +1,11 @@
-import clsx from "clsx";
+import {
+  CheckCircleIcon,
+  ClockIcon,
+  FireIcon,
+  XCircleIcon,
+} from "@heroicons/react/20/solid";
+
+import { Badge, type BadgeIcon, type BadgeTone } from "./Badge";
 
 export type StatusPillStatus =
   | "available"
@@ -8,43 +15,36 @@ export type StatusPillStatus =
 
 type StatusPillProps = {
   status?: StatusPillStatus;
+  /** Render a leading status icon (e.g. for the icon-only compact/mobile badge). */
+  withIcon?: boolean;
   className?: string;
 };
 
-const STATUS_CONFIG: Record<StatusPillStatus, { label: string; classes: string }> = {
-  available: {
-    label: "Available",
-    classes: "text-success bg-success-soft border-success",
-  },
-  "selling-fast": {
-    label: "Selling Fast",
-    classes: "text-warning bg-warning-soft border-warning",
-  },
-  "sold-out": {
-    label: "Sold Out",
-    classes: "text-danger bg-danger-soft border-danger",
-  },
-  ended: {
-    label: "Show Ended",
-    classes: "text-stub-ink bg-stub border-hair",
-  },
+const STATUS_CONFIG: Record<
+  StatusPillStatus,
+  { label: string; tone: BadgeTone; Icon: BadgeIcon }
+> = {
+  available: { label: "Available", tone: "success", Icon: CheckCircleIcon },
+  "selling-fast": { label: "Selling Fast", tone: "warning", Icon: FireIcon },
+  "sold-out": { label: "Sold Out", tone: "danger", Icon: XCircleIcon },
+  ended: { label: "Show Ended", tone: "neutral", Icon: ClockIcon },
 };
 
 /**
- * Uppercase mono status chip colored by availability (theme-constant tokens).
+ * Availability chip for a show, colored by status. A thin domain wrapper over
+ * the shared {@link Badge} primitive. Pass `withIcon` to prepend the status
+ * glyph — used by the mobile compact badge where the seats bar is hidden.
  */
-export function StatusPill({ status = "available", className }: StatusPillProps) {
-  const config = STATUS_CONFIG[status];
+export function StatusPill({
+  status = "available",
+  withIcon = false,
+  className,
+}: StatusPillProps) {
+  const { label, tone, Icon } = STATUS_CONFIG[status];
 
   return (
-    <span
-      className={clsx(
-        "inline-flex items-center font-mono uppercase text-meta tracking-wider rounded-pill border-hair px-2 py-0.5",
-        config.classes,
-        className,
-      )}
-    >
-      {config.label}
-    </span>
+    <Badge tone={tone} icon={withIcon ? Icon : undefined} className={className}>
+      {label}
+    </Badge>
   );
 }

--- a/packages/frontend/src/components/ui/TicketStub.tsx
+++ b/packages/frontend/src/components/ui/TicketStub.tsx
@@ -10,17 +10,17 @@ export function TicketStub({ className, children }: TicketStubProps) {
   return (
     <div
       className={clsx(
-        "relative bg-bg border-l-2 border-dashed border-line p-6 md:p-8",
+        "relative bg-bg md:border-l-2 md:border-dashed md:border-line p-6 md:p-8",
         className,
       )}
     >
       <span
         aria-hidden="true"
-        className="absolute -left-[7px] top-3 h-3.5 w-3.5 rounded-full bg-bg border-hair border-line"
+        className="absolute -left-[7px] top-3 hidden h-3.5 w-3.5 rounded-full bg-bg border-hair border-line md:block"
       />
       <span
         aria-hidden="true"
-        className="absolute -left-[7px] bottom-3 h-3.5 w-3.5 rounded-full bg-bg border-hair border-line"
+        className="absolute -left-[7px] bottom-3 hidden h-3.5 w-3.5 rounded-full bg-bg border-hair border-line md:block"
       />
       {children}
     </div>

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -56,7 +56,7 @@ export function App() {
         >
           <div className="flex min-h-screen flex-col bg-bg text-text">
             <Header />
-            <main className="w-full flex-1 px-10 pt-[34px] pb-[60px]">
+            <main className="w-full flex-1 px-4 pt-[34px] pb-[60px]">
               <Router onRouteChange={onRouteChange}>
                 <Route path="/" component={Home} />
                 <Route

--- a/packages/frontend/src/pages/Auth/Auth.css
+++ b/packages/frontend/src/pages/Auth/Auth.css
@@ -1,0 +1,13 @@
+/* Clerk widget dark-mode overrides */
+
+[data-theme="dark"] .cl-socialButtonsBlockButton__buttonText {
+  color: var(--text) !important;
+}
+
+[data-theme="dark"] .cl-signIn-start .cl-formFieldLabel {
+  color: var(--text) !important;
+}
+
+[data-theme="dark"] .cl-form_hasError .cl-formFieldLabel {
+  color: var(--text) !important;
+}

--- a/packages/frontend/src/pages/Auth/SignIn.tsx
+++ b/packages/frontend/src/pages/Auth/SignIn.tsx
@@ -4,6 +4,7 @@ import { getClerk } from "../../utils/clerk";
 import { Link } from "../../components/Link";
 import PageWrapper from "./PageWrapper";
 import { authAppearance } from "./authAppearance";
+import "./Auth.css";
 
 export default function SignIn() {
   const signInRef = useRef();
@@ -17,8 +18,6 @@ export default function SignIn() {
     <PageWrapper
       eyebrow="Members' Entrance"
       title="Take Your Seat"
-      subline="Welcome back — sign in to manage your reservations."
-      footnote="Secured by Clerk"
       footer={
         <>
           New to the Cellar?{" "}

--- a/packages/frontend/src/pages/Auth/SignUp.tsx
+++ b/packages/frontend/src/pages/Auth/SignUp.tsx
@@ -4,6 +4,7 @@ import { getClerk } from "../../utils/clerk";
 import { Link } from "../../components/Link";
 import PageWrapper from "./PageWrapper";
 import { authAppearance } from "./authAppearance";
+import "./Auth.css";
 
 export default function SignUp() {
   const signUpRef = useRef();
@@ -15,10 +16,7 @@ export default function SignUp() {
 
   return (
     <PageWrapper
-      eyebrow="New Members"
       title="Join the Cellar"
-      subline="Create an account to book and manage your reservations."
-      footnote="Secured by Clerk"
       footer={
         <>
           Already have a seat?{" "}

--- a/packages/frontend/src/pages/Auth/authAppearance.ts
+++ b/packages/frontend/src/pages/Auth/authAppearance.ts
@@ -28,7 +28,7 @@ export const authAppearance = {
     header: "hidden",
     footer: "hidden",
     socialButtonsBlockButton:
-      "border-hair border-line rounded-field bg-surface hover:bg-track",
+      "border-hair border-line rounded-field bg-surface hover:bg-track text-text",
     formButtonPrimary: "rounded-pill bg-solid hover:bg-solid-hover",
     dividerLine: "bg-line",
     dividerText: "text-muted font-mono text-meta",

--- a/packages/frontend/src/pages/Comic/ComicBannerImage.tsx
+++ b/packages/frontend/src/pages/Comic/ComicBannerImage.tsx
@@ -1,30 +1,62 @@
 import clsx from "clsx";
+import { useState } from "preact/hooks";
+
+const COVER_IMAGES = [
+  "/cellar.webp",
+  "/ComedyCellar_MacDougalstNYC.jpg",
+  "/TheStairs_empty.jpg",
+];
+
+function getRandomInt(max: number) {
+  return Math.floor(Math.random() * max);
+}
 
 /**
- * Cellar stage-photo placeholder banner. Per the vintage-marquee design this is
- * an intentional placeholder (diagonal cream-on-ink stripes), not a real photo.
- * The stripe colors are theme-independent literals — they read as a dark stage
- * wall in both light and dark mode — so they stay inline hex.
+ * Real cellar stage photo, picked at random from a small pool. Falls back to
+ * the diagonal cream-on-ink stripe placeholder if the photo fails to load; on
+ * hover the placeholder overlays the photo at reduced opacity.
  */
 export default function ComicBannerImage({ className }: { className?: string }) {
+  const [imgFailed, setImgFailed] = useState(false);
+  const [src] = useState(
+    () => COVER_IMAGES[getRandomInt(COVER_IMAGES.length)],
+  );
+
   return (
     <div
       className={clsx(
-        "relative flex h-[14.375rem] items-center justify-center",
+        "group relative flex h-[14.375rem] items-center justify-center overflow-hidden",
         className,
       )}
-      style={{
-        background: "#231F1A",
-        backgroundImage:
-          "repeating-linear-gradient(135deg, #2A251F 0 14px, #211D18 14px 28px)",
-      }}
     >
-      <span
-        className="font-mono uppercase text-caption text-[#6F665A]"
-        style={{ letterSpacing: "0.16em" }}
+      {!imgFailed && (
+        <img
+          src={src}
+          alt="Comedy Cellar stage"
+          loading="lazy"
+          onError={() => setImgFailed(true)}
+          className="absolute inset-0 h-full w-full object-cover"
+        />
+      )}
+      <div
+        aria-hidden="true"
+        className={clsx(
+          "absolute inset-0 flex items-center justify-center transition-opacity duration-150",
+          imgFailed ? "opacity-100" : "opacity-0 group-hover:opacity-80",
+        )}
+        style={{
+          background: "#231F1A",
+          backgroundImage:
+            "repeating-linear-gradient(135deg, #2A251F 0 14px, #211D18 14px 28px)",
+        }}
       >
-        Cellar stage photo
-      </span>
+        <span
+          className="font-mono uppercase text-caption text-[#6F665A]"
+          style={{ letterSpacing: "0.16em" }}
+        >
+          Cellar stage photo
+        </span>
+      </div>
     </div>
   );
 }

--- a/packages/frontend/src/pages/Comic/index.tsx
+++ b/packages/frontend/src/pages/Comic/index.tsx
@@ -51,6 +51,7 @@ export default function Comic() {
             <div className="flex items-end gap-6">
               <Avatar
                 name={comic.data.name}
+                img={comic.data.img}
                 size={132}
                 className="border-4 shadow-block"
               />

--- a/packages/frontend/src/pages/Comics/ComicItem.tsx
+++ b/packages/frontend/src/pages/Comics/ComicItem.tsx
@@ -1,4 +1,5 @@
 import { Comic } from "../../types";
+import { Img } from "../../components/Image";
 import { ShowCount } from "./ShowCount";
 import { getInitials, getSwatch } from "../../utils/swatches";
 
@@ -12,25 +13,57 @@ export function ComicItem({ comic }: { comic: Comic }) {
         href={`/comics/${comic.externalId}`}
         className="flex h-full flex-col overflow-hidden rounded-card border-hair border-line bg-surface shadow-block transition-all duration-150 hover:-translate-x-px hover:-translate-y-px hover:shadow-block-lg focus:outline-none focus-visible:-translate-x-px focus-visible:-translate-y-px focus-visible:shadow-block-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
       >
-        {/* Photo placeholder — swatch bg + centered Bebas initials */}
-        <div
-          className="relative flex h-44 items-center justify-center border-b-2 border-line"
-          style={{ backgroundColor: bg }}
-          role="img"
-          aria-label={`${comic.name}'s photo`}
-        >
-          <span
-            className="font-display text-8xl leading-none tracking-[0.04em]"
-            style={{ color: fg }}
-          >
-            {initials}
-          </span>
-          <span
-            className="absolute bottom-2 right-2.5 font-mono text-[8px] uppercase tracking-wider"
-            style={{ color: fg, opacity: 0.55 }}
-          >
-            PHOTO
-          </span>
+        {/* Photo — falls back to the swatch + initials placeholder when comic.img is missing */}
+        <div className="group relative h-44 overflow-hidden border-b-2 border-line">
+          {comic.img ? (
+            <>
+              <Img
+                alt={`${comic.name}'s photo`}
+                loading="lazy"
+                src={comic.img}
+                className="h-full w-full object-cover"
+              />
+              {/* Translucent placeholder overlay on hover */}
+              <div
+                className="absolute inset-0 flex items-center justify-center opacity-0 transition-opacity duration-150 group-hover:opacity-80"
+                style={{ backgroundColor: bg }}
+                aria-hidden="true"
+              >
+                <span
+                  className="font-display text-8xl leading-none tracking-[0.04em]"
+                  style={{ color: fg }}
+                >
+                  {initials}
+                </span>
+                <span
+                  className="absolute bottom-2 right-2.5 font-mono text-[8px] uppercase tracking-wider"
+                  style={{ color: fg, opacity: 0.55 }}
+                >
+                  PHOTO
+                </span>
+              </div>
+            </>
+          ) : (
+            <div
+              className="flex h-full items-center justify-center"
+              style={{ backgroundColor: bg }}
+              role="img"
+              aria-label={`${comic.name}'s photo`}
+            >
+              <span
+                className="font-display text-8xl leading-none tracking-[0.04em]"
+                style={{ color: fg }}
+              >
+                {initials}
+              </span>
+              <span
+                className="absolute bottom-2 right-2.5 font-mono text-[8px] uppercase tracking-wider"
+                style={{ color: fg, opacity: 0.55 }}
+              >
+                PHOTO
+              </span>
+            </div>
+          )}
         </div>
 
         {/* Body */}

--- a/packages/frontend/src/pages/Gallery/index.tsx
+++ b/packages/frontend/src/pages/Gallery/index.tsx
@@ -1,21 +1,23 @@
 import { useState } from "preact/hooks";
 import type { ComponentChildren } from "preact";
 
-import { Button } from "../../components/Button";
-import { Card, CardHeader, CardBody, CardFooter } from "../../components/Card";
-import { Input } from "../../components/Input";
-import { Link } from "../../components/Link";
-import { Checkbox } from "../../components/Checkbox";
-import { Spinner } from "../../components/Spinner";
-import { Perforation } from "../../components/Perforation";
+import { Button } from "@/components/Button";
+import { Card, CardHeader, CardBody, CardFooter } from "@/components/Card";
+import { Input } from "@/components/Input";
+import { Link } from "@/components/Link";
+import { Checkbox } from "@/components/Checkbox";
+import { Spinner } from "@/components/Spinner";
+import { Perforation } from "@/components/Perforation";
 
-import { Eyebrow } from "../../components/ui/Eyebrow";
-import { PageHeader } from "../../components/ui/PageHeader";
-import { Pill } from "../../components/ui/Pill";
-import { StatusPill } from "../../components/ui/StatusPill";
-import { ProgressBar } from "../../components/ui/ProgressBar";
-import { SegmentedToggle } from "../../components/ui/SegmentedToggle";
-import { Avatar } from "../../components/ui/Avatar";
+import { Eyebrow } from "@/components/ui/Eyebrow";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { Pill } from "@/components/ui/Pill";
+import { Badge } from "@/components/ui/Badge";
+import { BellAlertIcon, BellSlashIcon } from "@heroicons/react/20/solid";
+import { StatusPill } from "@/components/ui/StatusPill";
+import { ProgressBar } from "@/components/ui/ProgressBar";
+import { SegmentedToggle } from "@/components/ui/SegmentedToggle";
+import { Avatar } from "@/components/ui/Avatar";
 import { FlameMeter } from "../../components/ui/FlameMeter";
 import { TicketStub } from "../../components/ui/TicketStub";
 import { TicketCard } from "../../components/ui/TicketCard";
@@ -131,6 +133,18 @@ export default function Gallery() {
               <StatusPill status="available" />
               <StatusPill status="selling-fast" />
               <StatusPill status="sold-out" />
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <StatusPill status="available" withIcon />
+              <StatusPill status="selling-fast" withIcon />
+              <StatusPill status="sold-out" withIcon />
+              <StatusPill status="ended" withIcon />
+              <Badge tone="success" icon={BellAlertIcon}>
+                Enabled
+              </Badge>
+              <Badge tone="muted" icon={BellSlashIcon}>
+                Muted
+              </Badge>
             </div>
             <div className="flex w-72 flex-col gap-3">
               <ProgressBar pct={30} status="available" />

--- a/packages/frontend/src/pages/Home/CompactLoader.tsx
+++ b/packages/frontend/src/pages/Home/CompactLoader.tsx
@@ -1,9 +1,9 @@
-const GRID = "grid-cols-[62px_minmax(0,1fr)_104px_88px_108px]";
+import { GRID } from "./CompactRow";
 
 function CompactRowLoader() {
   return (
     <div
-      className={`grid ${GRID} animate-pulse items-center gap-[13px] rounded-[10px] border-hair border-line bg-surface py-[7px] pl-[7px] pr-3.5 shadow-block-sm`}
+      className={`grid ${GRID} animate-pulse items-center rounded-lg border-hair border-line bg-surface py-1.75 pl-1.75 pr-3.5 shadow-block-sm`}
     >
       {/* Time stub */}
       <div className="h-11 rounded-[7px] bg-track" />
@@ -12,19 +12,24 @@ function CompactRowLoader() {
       <div className="min-w-0 space-y-1.5">
         <div className="h-4 w-44 max-w-full rounded bg-track" />
         <div className="h-3 w-32 max-w-full rounded bg-track" />
+        {/* Mobile-only availability badge */}
+        <div className="h-4 w-24 rounded-pill bg-track sm:hidden" />
       </div>
 
       {/* Seats + progress */}
-      <div className="space-y-1.5">
+      <div className="hidden space-y-1.5 sm:block">
         <div className="h-3 w-16 rounded bg-track" />
         <div className="h-1.5 rounded-pill bg-track" />
       </div>
 
       {/* Status */}
-      <div className="h-4 w-16 justify-self-center rounded-pill bg-track" />
+      <div className="hidden h-4 w-16 justify-self-center rounded-pill bg-track sm:block" />
 
       {/* Action */}
-      <div className="h-8 w-24 justify-self-end rounded-pill bg-track" />
+      <div className="h-8 w-16 justify-self-end rounded-pill bg-track sm:w-24" />
+
+      {/* Chevron */}
+      <div className="size-3 justify-self-center rounded bg-track" />
     </div>
   );
 }
@@ -36,19 +41,18 @@ function CompactRowLoader() {
 export function CompactLoader() {
   return (
     <div>
-      <div
-        className={`grid ${GRID} items-center gap-[13px] px-[7px] pb-2 pr-3.5`}
-      >
+      <div className={`grid ${GRID} items-center px-1.75 pb-2 pr-3.5`}>
         <span />
         <span className="font-mono text-meta uppercase tracking-wide text-faint">
           Show
         </span>
-        <span className="font-mono text-meta uppercase tracking-wide text-faint">
+        <span className="hidden font-mono text-meta uppercase tracking-wide text-faint sm:block">
           Seats
         </span>
-        <span className="justify-self-center font-mono text-meta uppercase tracking-wide text-faint">
+        <span className="hidden justify-self-center font-mono text-meta uppercase tracking-wide text-faint sm:block">
           Status
         </span>
+        <span />
         <span />
       </div>
       <ol className="flex flex-col gap-[9px]">

--- a/packages/frontend/src/pages/Home/CompactRow.tsx
+++ b/packages/frontend/src/pages/Home/CompactRow.tsx
@@ -1,91 +1,183 @@
 import clsx from "clsx";
+import { ChevronDownIcon } from "@heroicons/react/20/solid";
 
 import { Link } from "../../components/Link";
 import { StatusPill } from "../../components/ui/StatusPill";
 import { ProgressBar } from "../../components/ui/ProgressBar";
-import { Show } from "../../types";
+import { Avatar } from "../../components/ui/Avatar";
+import { LineUp, Show } from "../../types";
 import { getShowView } from "./types";
 
-const GRID = "grid-cols-[62px_minmax(0,1fr)_104px_88px_108px]";
+export const GRID = "grid-cols-[54px_minmax(0,1fr)_auto_20px] gap-2.5 sm:grid-cols-[62px_minmax(0,1fr)_104px_88px_108px_26px] sm:gap-4";
+
+type CompactRowProps = {
+  show: Show;
+  lineUp: LineUp;
+  isLineUpLoading: boolean;
+  isOpen: boolean;
+  onToggle: () => void;
+};
 
 /**
  * Dense one-line variant of a show row for the "Compact" view mode. Same data
- * and reserve routing as the relaxed `Event` card, laid out as a grid.
+ * and reserve routing as the relaxed `Event` card, laid out as a grid. The
+ * whole row toggles a fused lineup panel (pill chips) below the row.
  */
-export function CompactRow({ show }: { show: Show }) {
+export function CompactRow({
+  show,
+  lineUp,
+  isLineUpLoading,
+  isOpen,
+  onToggle,
+}: CompactRowProps) {
   const view = getShowView(show);
+  const { acts } = lineUp;
+
+  const lineupNote = isLineUpLoading
+    ? "…"
+    : acts.length > 0
+      ? `${acts.length} comics`
+      : "lineup TBA";
+  const lineupHeading =
+    acts.length > 0 ? `Tonight's Lineup · ${acts.length} acts` : "Lineup";
 
   return (
-    <div
-      className={clsx(
-        "grid items-center gap-[13px] rounded-[10px] border-hair border-line bg-surface py-[7px] pl-[7px] pr-3.5 shadow-block-sm transition hover:-translate-x-px hover:-translate-y-px hover:shadow-block",
-        GRID
-      )}
-    >
-      {/* Time stub */}
+    <div className="overflow-hidden rounded-[10px] border-hair border-line bg-surface shadow-block-sm transition hover:-translate-x-px hover:-translate-y-px hover:shadow-block">
+      {/* Row */}
       <div
+        onClick={isLineUpLoading ? undefined : onToggle}
         className={clsx(
-          "rounded-[7px] border-hair border-line py-[5px] text-center",
-          view.closed ? "bg-stub" : "bg-brand"
+          "grid cursor-pointer items-center py-[7px] pl-[7px] pr-3.5 transition-colors hover:bg-track",
+          GRID
         )}
       >
+        {/* Time stub */}
         <div
           className={clsx(
-            "font-display text-[21px] leading-[0.95]",
-            view.closed ? "text-stub-ink" : "text-brand-fg"
+            "rounded-[8px] border-hair border-line py-[5px] text-center",
+            view.closed ? "bg-stub" : "bg-brand"
           )}
         >
-          {view.time}
-        </div>
-        <div
-          className={clsx(
-            "font-mono text-[9px]",
-            view.closed ? "text-stub-ink" : "text-brand-fg"
-          )}
-        >
-          {view.ampm}
-        </div>
-      </div>
-
-      {/* Title + venue */}
-      <div className="min-w-0">
-        <div
-          className="truncate font-sans text-caption font-bold text-text"
-          title={show.description}
-        >
-          {view.title}
-        </div>
-        <div className="truncate font-mono text-[11px] text-muted">
-          {view.venue}
-        </div>
-      </div>
-
-      {/* Seats + progress */}
-      <div>
-        <div className="mb-1 font-mono text-meta text-muted">
-          {view.capLabel}
-        </div>
-        <ProgressBar pct={view.pct} status={view.status} />
-      </div>
-
-      {/* Status */}
-      <StatusPill status={view.status} className="justify-self-center" />
-
-      {/* Action */}
-      <div className="justify-self-end">
-        {view.reservable ? (
-          <Link
-            href={`/reservations/${show.timestamp}`}
-            className="inline-flex items-center whitespace-nowrap rounded-pill bg-solid px-3.5 py-2 font-sans text-[12px] font-bold text-solid-fg! no-underline transition hover:bg-brand hover:text-brand-fg! hover:no-underline"
+          <div
+            className={clsx(
+              "font-display text-[21px] leading-[0.95]",
+              view.closed ? "text-stub-ink" : "text-brand-fg"
+            )}
           >
-            Reserve &rarr;
-          </Link>
-        ) : (
-          <span className="whitespace-nowrap font-mono text-meta text-faint">
-            Closed
-          </span>
-        )}
+            {view.time}
+          </div>
+          <div
+            className={clsx(
+              "font-mono text-[9px]",
+              view.closed ? "text-stub-ink" : "text-brand-fg"
+            )}
+          >
+            {view.ampm}
+          </div>
+        </div>
+
+        {/* Title + venue + lineup note */}
+        <div className="min-w-0">
+          <div
+            className="truncate font-sans text-caption font-bold text-text"
+            title={show.description}
+          >
+            {view.title}
+          </div>
+          <div className="truncate font-mono text-[11px] text-muted">
+            {view.venue} · {lineupNote}
+          </div>
+
+          {/* Mobile-only availability badge (seats bar + desktop pill are sm+) */}
+          <div className="mt-1.5 sm:hidden">
+            <StatusPill status={view.status} withIcon className="py-0" />
+          </div>
+        </div>
+
+        {/* Seats + progress */}
+        <div className="hidden sm:block">
+          <div className="mb-1 font-mono text-meta text-muted">
+            {view.capLabel}
+          </div>
+          <ProgressBar pct={view.pct} status={view.status} />
+        </div>
+
+        {/* Status */}
+        <div className="hidden justify-self-center sm:block">
+          <StatusPill status={view.status} />
+        </div>
+
+        {/* Action */}
+        <div className="justify-self-end">
+          {view.reservable ? (
+            <Link
+              href={`/reservations/${show.timestamp}`}
+              onClick={(event: MouseEvent) => event.stopPropagation()}
+              className="inline-flex items-center whitespace-nowrap rounded-pill bg-solid px-2.5 py-1.5 font-sans text-[11px] font-bold text-solid-fg! no-underline transition hover:bg-brand hover:text-brand-fg! hover:no-underline sm:px-3.5 sm:py-2 sm:text-[12px]"
+            >
+              Reserve &rarr;
+            </Link>
+          ) : (
+            <span className="whitespace-nowrap font-mono text-meta text-faint">
+              Closed
+            </span>
+          )}
+        </div>
+
+        {/* Chevron */}
+        <button
+          type="button"
+          disabled={isLineUpLoading}
+          aria-expanded={isOpen}
+          aria-label={isOpen ? "Hide lineup" : "Show lineup"}
+          onClick={(event: MouseEvent) => {
+            event.stopPropagation();
+            onToggle();
+          }}
+          className="grid cursor-pointer place-items-center justify-self-center outline-none disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
+        >
+          <ChevronDownIcon
+            aria-hidden="true"
+            className={clsx(
+              "size-3.5 text-text transition-transform",
+              isOpen && "rotate-180"
+            )}
+          />
+        </button>
       </div>
+
+      {/* Fused lineup panel */}
+      {isOpen && (
+        <div className="animate-lineup-in border-t-[1.5px] border-dashed border-line bg-bg px-4 pb-[15px] pt-3.5">
+          <div className="mb-[11px] font-mono text-meta uppercase tracking-wider text-gold">
+            {lineupHeading}
+          </div>
+          {acts.length > 0 ? (
+            <ul role="list" className="flex flex-wrap gap-[9px]">
+              {acts.map((act, index) => (
+                <li
+                  key={index}
+                  className="flex items-center gap-[9px] rounded-pill border-hair border-line bg-surface py-[5px] pl-[5px] pr-3.5 shadow-[1.5px_2px_0_var(--shadow)]"
+                >
+                  <Avatar name={act.name} size={30} />
+                  <a
+                    href={act.website}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="whitespace-nowrap font-sans text-caption font-bold text-text hover:underline"
+                  >
+                    {act.name}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="font-sans text-caption font-semibold text-faint">
+              No acts announced yet — usually posted the morning of the show.
+            </p>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/frontend/src/pages/Home/index.tsx
+++ b/packages/frontend/src/pages/Home/index.tsx
@@ -7,7 +7,7 @@ import { EventLoader } from "../../components/EventLoader";
 import { PageHeader } from "../../components/ui/PageHeader";
 import { SegmentedToggle } from "../../components/ui/SegmentedToggle";
 import { CompactLoader } from "./CompactLoader";
-import { CompactRow } from "./CompactRow";
+import { CompactRow, GRID } from "./CompactRow";
 import type { ViewMode } from "./types";
 import { getToday } from "../../utils/date";
 import { format, isPast } from "date-fns";
@@ -44,6 +44,11 @@ function formatEyebrowDate(date: string): string {
 export default function Home() {
   const { query, route } = useLocation();
   const [mode, setMode] = useState<ViewMode>(() => getInitialViewMode());
+  const [openShows, setOpenShows] = useState<Record<string, boolean>>({});
+
+  const toggleShow = (timestamp: string) => {
+    setOpenShows((prev) => ({ ...prev, [timestamp]: !prev[timestamp] }));
+  };
 
   const handleModeChange = (next: ViewMode) => {
     setMode(next);
@@ -160,37 +165,51 @@ export default function Home() {
                     <Event
                       show={show}
                       lineUp={
-                        (!lineUpData.isLoading &&
-                          findLineUp(show.timestamp)) ?? {
+                        findLineUp(show.timestamp) ?? {
                           reservationUrl: "",
                           timestamp: 0,
                           acts: [],
                         }
                       }
                       isLineUpLoading={lineUpData.isLoading}
+                      isOpen={!!openShows[String(show.timestamp)]}
+                      onToggle={() => toggleShow(String(show.timestamp))}
                     />
                   </li>
                 ))}
               </ol>
             ) : (
               <div>
-                <div className="grid grid-cols-[62px_minmax(0,1fr)_104px_88px_108px] items-center gap-[13px] px-[7px] pb-2 pr-3.5">
+                <div className={`grid ${GRID} items-center px-[8px] pb-2 pr-3.5`}>
                   <span />
                   <span className="font-mono text-meta uppercase tracking-wide text-faint">
                     Show
                   </span>
-                  <span className="font-mono text-meta uppercase tracking-wide text-faint">
+                  <span className="hidden font-mono text-meta uppercase tracking-wide text-faint sm:block">
                     Seats
                   </span>
-                  <span className="justify-self-center font-mono text-meta uppercase tracking-wide text-faint">
+                  <span className="hidden justify-self-center font-mono text-meta uppercase tracking-wide text-faint sm:block">
                     Status
                   </span>
+                  <span />
                   <span />
                 </div>
                 <ol className="flex flex-col gap-[9px]">
                   {shows.map((show) => (
                     <li key={show.id} data-timestamp={show.timestamp}>
-                      <CompactRow show={show} />
+                      <CompactRow
+                        show={show}
+                        lineUp={
+                          findLineUp(show.timestamp) ?? {
+                            reservationUrl: "",
+                            timestamp: 0,
+                            acts: [],
+                          }
+                        }
+                        isLineUpLoading={lineUpData.isLoading}
+                        isOpen={!!openShows[String(show.timestamp)]}
+                        onToggle={() => toggleShow(String(show.timestamp))}
+                      />
                     </li>
                   ))}
                 </ol>

--- a/packages/frontend/src/pages/Profile/index.tsx
+++ b/packages/frontend/src/pages/Profile/index.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from "preact/hooks";
 import PageWrapper from "../Auth/PageWrapper";
 import { ProfileSettings } from "./profileSettings";
 import { getClerk } from "../../utils/clerk";
+import { authAppearance } from "../Auth/authAppearance";
 
 import { Card, CardBody, CardHeader } from "../../components/Card";
 import { Eyebrow } from "../../components/ui/Eyebrow";
@@ -18,13 +19,13 @@ export default function Profile() {
   const profileRef = useRef();
   useEffect(() => {
     getClerk().then((clerk) => {
-      clerk.mountUserProfile(profileRef.current);
+      clerk.mountUserProfile(profileRef.current, { appearance: authAppearance });
     });
   }, []);
 
   return (
     <PageWrapper>
-      <div className="w-full max-w-[820px] px-6 pb-16">
+      <div className="w-full max-w-full px-6 pb-16">
         <PageHeader
           eyebrow="Your Account"
           title="Backstage Pass"

--- a/packages/frontend/src/pages/Profile/profileSettings.tsx
+++ b/packages/frontend/src/pages/Profile/profileSettings.tsx
@@ -1,15 +1,16 @@
-import { Card, CardBody, CardHeader } from "../../components/Card";
-import { ComicNotification, Settings } from "../../types";
-import { fetchSettings, updateSettings } from "../../utils/api";
+import { Card, CardBody, CardHeader } from "@/components/Card";
+import { ComicNotification, Settings } from "@/types";
+import { fetchSettings, updateSettings } from "@/utils/api";
 import { useMutation, useQuery } from "@tanstack/react-query";
 
-import { Button } from "../../components/Button";
-import { Checkbox } from "../../components/Checkbox";
-import { Link } from "../../components/Link";
-import { PageLoader } from "../../components/PageLoader";
+import { Button } from "@/components/Button";
+import { Checkbox } from "@/components/Checkbox";
+import { Link } from "@/components/Link";
+import { PageLoader } from "@/components/PageLoader";
 
-import { Avatar } from "../../components/ui/Avatar";
-import { Pill } from "../../components/ui/Pill";
+import { Avatar } from "@/components/ui/Avatar";
+import { Badge } from "@/components/ui/Badge";
+import { BellAlertIcon, BellSlashIcon } from "@heroicons/react/20/solid";
 
 export function ProfileSettings() {
   const { data, isLoading } = useQuery<Settings>({
@@ -81,9 +82,13 @@ export function ProfileSettings() {
 
 function NotificationPill({ enabled }: { enabled: boolean }) {
   return enabled ? (
-    <Pill className="border-success bg-success-soft text-success">Enabled</Pill>
+    <Badge tone="success" icon={BellAlertIcon}>
+      Enabled
+    </Badge>
   ) : (
-    <Pill className="text-faint">Muted</Pill>
+    <Badge tone="muted" icon={BellSlashIcon}>
+      Muted
+    </Badge>
   );
 }
 
@@ -100,7 +105,7 @@ export function ComicNotificationList({
           className="flex items-center justify-between gap-4 py-3.5 first:pt-0 last:pb-0"
         >
           <div className="flex min-w-0 items-center gap-3.5">
-            <Avatar name={comicNotification.name} size={42} />
+            <Avatar name={comicNotification.name} img={comicNotification.comic} size={42} />
             <Link
               href={`/comics/${comicNotification.comicId}`}
               className="truncate text-body font-bold text-text"

--- a/packages/frontend/src/pages/Updates/data.ts
+++ b/packages/frontend/src/pages/Updates/data.ts
@@ -6,6 +6,11 @@ export interface Update {
 
 export const updates: Update[] = [
   {
+    date: "July 2026",
+    title: "Redesign",
+    text: "We've given the whole site a fresh look! New vintage marquee styling, equal-height comic cards, dark mode, and other polish across every page.",
+  },
+  {
     date: "September 2025",
     title: "Persistent Comic Search",
     text: "Comic searches now stay in the URL! This means you can bookmark search results, share links with specific searches, and your search will persist when you refresh the page or navigate back.",

--- a/packages/frontend/src/theme.css
+++ b/packages/frontend/src/theme.css
@@ -147,6 +147,20 @@ html[data-theme="dark"] {
   --shadow-block:    3px 4px 0 var(--shadow);
   --shadow-block-md: 4px 5px 0 var(--shadow);
   --shadow-block-lg: 5px 6px 0 var(--shadow);
+
+  /* ---- Animations ---- */
+  --animate-lineup-in: lineupIn 0.22s ease; /* animate-lineup-in */
+
+  @keyframes lineupIn {
+    from {
+      opacity: 0;
+      transform: translateY(-6px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
 }
 
 /* ----------------------------------------------------------------------------
@@ -155,4 +169,9 @@ html[data-theme="dark"] {
    ---------------------------------------------------------------------------- */
 @utility border-hair {
   border-width: 1.5px;
+}
+
+/* Calendar yellow shadow in dark mode only */
+[data-theme="dark"] .calendar-dark-shadow {
+  --shadow: #F3C44C;
 }

--- a/packages/frontend/src/types.ts
+++ b/packages/frontend/src/types.ts
@@ -93,6 +93,6 @@ export type Settings = {
 export type ComicNotification = {
   comicId: string;
   name: string;
-  comic: string;
+  comic: string;  /* image URL */
   enabled: boolean;
 };

--- a/plan/IMPLEMENTATION_PLAN.md
+++ b/plan/IMPLEMENTATION_PLAN.md
@@ -121,13 +121,30 @@ is a distinct, non-overlapping owner.
 - `src/components/CalendarButton.tsx` — day cell; today = 32px yellow disc; out-of-month faint.
 - `src/components/Event.tsx` — **Relaxed** ticket card: 112px time stub (`border-right:2px dashed`,
   yellow or stub-gray), rotated SOLD stamp, title, `StatusPill`, venue·cap meta, `ProgressBar`,
-  Reserve pill → `/reservations/:timestamp`.
-- **NEW** `src/pages/Home/CompactRow.tsx` — compact dense-grid row variant.
+  Reserve pill → `/reservations/:timestamp`. **Lineup expand/collapse (per
+  `Home Redesign.dc.html`, updated):** the whole card header is the click target (not just a
+  small icon button) — clicking anywhere except the Reserve pill toggles the lineup (Reserve
+  link stops propagation). Chevron rotates 180° in place (no icon swap) with a short
+  transform transition. The lineup panel is **fused into the same card** — `border-top: 2px
+  dashed var(--line)`, `background: var(--bg)`, no gap/shadow of its own — not a detached box.
+  Meta line gains a third segment: `venue · capacity · "{n} comics"` (or `"lineup TBA"` when
+  empty). Panel opens with a heading `"Tonight's Lineup · {n} acts"` above the `Act` rows; empty
+  state is richer than plain text — a dashed-circle `?` glyph + "Lineup not announced yet" +
+  "Acts are usually posted the morning of the show." subtext.
+- **NEW** `src/pages/Home/CompactRow.tsx` — compact dense-grid row variant. **Same lineup
+  expand/collapse as Relaxed**, condensed: add a 6th grid column (~26px) for a small rotating
+  chevron; clicking the row (except Reserve) toggles; expanded panel spans full width below the
+  row (`border-top: 1.5px dashed`, `lineupIn` fade/slide-in) and renders acts as **wrapped pill
+  chips** (30px avatar + name only, no credits/description) rather than the Relaxed list layout.
+  Needs `lineUp`/`isLineUpLoading` props threaded in from the assembler (currently only
+  `Event` receives them).
 - `src/components/EventLoader.tsx` — skeleton in new style.
-- `src/components/Act.tsx` + `src/components/Availablity.tsx` — lineup act + status (one agent).
+- `src/components/Act.tsx` — lineup act row (name, credits/description, avatar). `Availablity.tsx`
+  has been folded into `Event.tsx` directly (no longer a separate single-consumer file).
 - `src/pages/Home/index.tsx` (assembler) — `PageHeader`, 2-col grid `288px 1fr`, Relaxed/Compact
   `SegmentedToggle` (local `mode`), keep `fetchShows`/`fetchLineUp`; derive view-model
-  (pct, status, colors). Move shared `src/utils/deriveShowDetails.ts` work here if Home-only.
+  (pct, status, colors, lineup note/heading/empty-state, `isOpen`/`onToggle` per show). Pass
+  lineup data + toggle state to **both** `Event` and `CompactRow`.
 
 ### Comics — `src/pages/Comics/` (+ SearchInput) — ~4 agents
 - `src/components/SearchInput.tsx` — pill `⌕` search input (keep debounce).
@@ -177,8 +194,12 @@ is a distinct, non-overlapping owner.
 - Minor reskin: `PageHeader` + surface card.
 
 ### Skipped
-- **`Home Redesign.dc.html`** — exploration canvas, not a route. The Relaxed/Compact toggle on Home
-  already subsumes both directions. Do not build.
+- **`Home Redesign.dc.html`** as a standalone route — still not a route; it's the side-by-side
+  canvas exploration of Roomy vs Condensed. The Relaxed/Compact toggle on Home subsumes both
+  directions, so no new page is built from it. **However**, as of the latest handoff update this
+  file is no longer purely exploratory — it now specifies the click-to-expand lineup behavior
+  (see Home section above), which **is** in scope and must be built into the live `Event`/
+  `CompactRow` components on the real Home page.
 
 ---
 
@@ -220,6 +241,10 @@ on the other agents finishing pixel work.
   persists across reload (`localStorage["cc-theme"]`).
 - **Smoke flows:** Home → Reserve CTA → form; Comics search + `?q=` → Comic detail; Profile
   notification toggles persist via `updateSettings`.
+- **Home lineup expand/collapse:** in both Relaxed and Compact modes, clicking a show card/row
+  (outside the Reserve pill) opens the fused lineup panel with correct heading/empty-state and
+  chevron rotation; clicking Reserve navigates without toggling; collapsing/re-expanding
+  preserves per-show state independently.
 
 ## Open notes / divergences to honor during re-skin
 - **Auth & Profile account** stay on **Clerk's mounted widgets** (themed via `appearance`), not the

--- a/plan/README.md
+++ b/plan/README.md
@@ -79,22 +79,42 @@ items start-aligned.
     background = brand yellow (or `#E9E3D6` stub-gray if sold out), showing time (Bebas 34px) +
     AM/PM (mono 11px). A rotated "SOLD" stamp (mono 9px, `danger` red, bordered, `rotate(-8deg)`)
     appears bottom of stub when sold out. Right side: title (Archivo 800 19px) + status pill
-    (mono 10px uppercase; color/tint per status) + venue·capacity meta (mono 12px) + a
+    (mono 10px uppercase; color/tint per status) + a **rotating chevron** (▾, 26px circle,
+    `1.5px solid var(--line)`, `transform: rotate(180deg)` when open) + venue·capacity·**lineup**
+    meta (mono 12px — third segment reads `"{n} comics"` or `"lineup TBA"`) + a
     **seat progress bar** (6px track `var(--track)`, fill colored per status, width = % full) +
     a "Reserve Tickets →" pill (`var(--solid)`/`var(--on-solid)`, hover flips to yellow/ink) or
     "Reservations closed" text.
-  - **Compact rows:** same data as a dense grid `62px minmax(0,1fr) 104px 88px 108px`, gap 13px,
-    with a column header row (Show / Seats / Status). Smaller stub (radius 7px), truncated title,
-    thin 5px progress bar, status pill, "Reserve →" / "Closed".
-- **State:** `mode: 'relaxed' | 'compact'` (local). Show records are derived (see Data below).
+  - **Compact rows:** same data as a dense grid `62px minmax(0,1fr) 104px 88px 108px 26px` (6th
+    column added for the chevron), gap 16px, with a column header row (Show / Seats / Status).
+    Smaller stub (radius 7px), truncated title, thin 5px progress bar, status pill, "Reserve →" /
+    "Closed", trailing chevron.
+  - **Lineup expand/collapse (both variants):** the row/card (excluding the Reserve pill, which
+    stops click propagation) is the toggle target — the whole thing is clickable, not just the
+    chevron. Expanding reveals the show's lineup **fused into the same card**
+    (`border-top:2px dashed var(--line)` for Relaxed / `1.5px dashed` for Compact,
+    `background:var(--bg)`, fade+slide-in `lineupIn` animation ~0.22s) — not a detached panel.
+    Heading: `"Tonight's Lineup · {n} acts"`. Relaxed lists each act as a row (46px swatch avatar
+    with initials, name, credits). Compact renders acts as wrapped **pill chips** (30px avatar +
+    name only). Empty state (no lineup announced): a dashed-circle `?` glyph + "Lineup not
+    announced yet" + "Acts are usually posted the morning of the show." Per-show open/closed
+    state is independent (multiple shows can be expanded at once).
+- **State:** `mode: 'relaxed' | 'compact'` (local); per-show `isOpen` (local, keyed by show
+  index/timestamp) drives the lineup toggle. Show records are derived (see Data below).
 - **Hover:** cards translate `(-1px,-1px)` and shadow grows to `5px 6px 0` (compact: `4px 5px 0`).
+  The clickable row also gets a subtle background tint on hover (the mock's local `--hover` var
+  isn't in `theme.css`'s token set — use the existing `hover:bg-track` utility instead).
 
-### 2. Home Redesign — `Home Redesign.dc.html`  (exploration, not a route)
+### 2. Home Redesign — `Home Redesign.dc.html`  (canvas exploration — now normative for the
+lineup interaction)
 Two alternate Home treatments shown **side by side on a pannable canvas** (uses
 `design_doc_mode=canvas`): "The Marquee — Roomy" and "The Marquee — Condensed". Same content as
 Home; the Condensed variant fits the whole night on screen using the compact table layout and a
-smaller hero. **Treat as reference for layout alternatives** — ship the chosen direction (the
-live Home above uses the Relaxed/Compact toggle, which subsumes both).
+smaller hero. **Layout direction is reference-only** — ship the chosen direction (the live Home
+above uses the Relaxed/Compact toggle, which subsumes both). **The click-to-expand lineup
+behavior specified here (chevron, fused panel, heading, empty state, pill-chip vs list act
+rendering — see section 1) is in scope and must be built on the live Home page for both view
+modes.**
 
 ### 3. Comics — `Comics.dc.html`  (route: `/comics`)
 **Purpose:** Browse/search the comic roster.

--- a/plan/designs/Home Redesign.dc.html
+++ b/plan/designs/Home Redesign.dc.html
@@ -14,14 +14,42 @@
   <meta name="design_doc_mode" content="canvas">
   <style>
     @keyframes spot { 0%,100%{box-shadow:0 0 0 0 rgba(243,196,76,0);} 50%{box-shadow:0 0 22px 3px rgba(243,196,76,.4);} }
-    body { margin:0; }
+    @keyframes lineupIn { from{opacity:0; transform:translateY(-6px);} to{opacity:1; transform:translateY(0);} }
+    html, body { margin:0; }
+    body { background:var(--bg); }
+    :root{
+      --bg:#FBF6EC; --surface:#ffffff; --text:#1A1714; --muted:#857B6D; --faint:#A99F8E;
+      --line:#1A1714; --shadow:#1A1714; --track:#EDE7DA; --hover:#FEFBF3;
+      --solid:#1A1714; --on-solid:#F3C44C;
+    }
+    html[data-theme="dark"]{
+      --bg:#16130E; --surface:#221E17; --text:#F2ECE0; --muted:#A99F90; --faint:#7C7468;
+      --line:#3C352B; --shadow:#070503; --track:#322C22; --hover:#2A251D;
+      --solid:#F3C44C; --on-solid:#1A1714;
+    }
   </style>
+  <script>
+(function(){
+  try{ if(localStorage.getItem('cc-theme')==='dark') document.documentElement.setAttribute('data-theme','dark'); }catch(e){}
+  function mk(){
+    if(document.getElementById('cc-theme-btn')) return;
+    if(!document.body){ return setTimeout(mk,40); }
+    var b=document.createElement('button');
+    b.id='cc-theme-btn';
+    b.style.cssText='position:fixed;right:18px;bottom:18px;z-index:99999;width:46px;height:46px;border-radius:50%;border:1.5px solid #1A1714;background:#F3C44C;color:#1A1714;font-size:20px;line-height:1;cursor:pointer;box-shadow:2px 3px 0 #1A1714;display:flex;align-items:center;justify-content:center;font-family:Archivo,sans-serif;';
+    function sync(){var d=document.documentElement.getAttribute('data-theme')==='dark';b.textContent=d?'\u2600':'\u263E';b.title=d?'Switch to light mode':'Switch to dark mode';}
+    b.onclick=function(){var d=document.documentElement.getAttribute('data-theme')==='dark';if(d){document.documentElement.removeAttribute('data-theme');try{localStorage.setItem('cc-theme','light')}catch(e){}}else{document.documentElement.setAttribute('data-theme','dark');try{localStorage.setItem('cc-theme','dark')}catch(e){}}sync();};
+    sync(); document.body.appendChild(b);
+  }
+  mk();
+})();
+  </script>
 </helmet>
 
 <!-- ============ DIRECTION A — THE MARQUEE ============ -->
 <div style="position:absolute; left:0; top:0; width:1320px;">
-  <div data-drags-parent="1" style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:.18em; text-transform:uppercase; color:#4b4438; margin-bottom:14px;">The Marquee — Roomy</div>
-  <div style="background:#FBF6EC; border-radius:14px; overflow:hidden; box-shadow:0 30px 70px -22px rgba(0,0,0,.4); border:1px solid rgba(0,0,0,.06);">
+  <div data-drags-parent="1" style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:.18em; text-transform:uppercase; color:var(--muted); margin-bottom:14px;">The Marquee — Roomy · click a show for the lineup</div>
+  <div style="background:var(--bg); border-radius:14px; overflow:hidden; box-shadow:0 30px 70px -22px rgba(0,0,0,.4); border:1px solid rgba(0,0,0,.06);">
 
     <div style="background:#F3C44C; padding:16px 40px; display:flex; align-items:center; justify-content:space-between;">
       <div style="display:flex; align-items:baseline; gap:11px;">
@@ -40,28 +68,28 @@
 
     <div style="padding:34px 40px 16px;">
       <div style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:.2em; text-transform:uppercase; color:#9A7B1E;">Sunday · June 28, 2026</div>
-      <h1 style="font-family:'Bebas Neue'; font-size:64px; line-height:.9; letter-spacing:.01em; color:#1A1714; margin:8px 0 8px;">Tonight at the Cellar</h1>
-      <div style="font-family:'Archivo'; font-size:15px; color:#6B6357;">12 shows across 3 rooms — <span style="color:#1E8E4E; font-weight:700;">8 still available</span></div>
+      <h1 style="font-family:'Bebas Neue'; font-size:64px; line-height:.9; letter-spacing:.01em; color:var(--text); margin:8px 0 8px;">Tonight at the Cellar</h1>
+      <div style="font-family:'Archivo'; font-size:15px; color:var(--muted);">12 shows across 3 rooms — <span style="color:#1E8E4E; font-weight:700;">8 still available</span></div>
     </div>
 
     <div style="display:grid; grid-template-columns:288px 1fr; gap:32px; padding:14px 40px 46px; align-items:start;">
 
-      <aside style="background:#fff; border:1.5px solid #1A1714; border-radius:14px; padding:18px 18px 20px; box-shadow:4px 5px 0 #1A1714;">
+      <aside style="background:var(--surface); border:1.5px solid var(--line); border-radius:14px; padding:18px 18px 20px; box-shadow:4px 5px 0 var(--shadow);">
         <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:14px;">
-          <span style="display:inline-flex; align-items:center; justify-content:center; width:28px; height:28px; border:1.5px solid #1A1714; border-radius:50%; font-family:'Archivo'; font-weight:700; cursor:pointer;">‹</span>
-          <span style="font-family:'Bebas Neue'; font-size:23px; letter-spacing:.04em; color:#1A1714;">June 2026</span>
-          <span style="display:inline-flex; align-items:center; justify-content:center; width:28px; height:28px; border:1.5px solid #1A1714; border-radius:50%; font-family:'Archivo'; font-weight:700; cursor:pointer;">›</span>
+          <span style="display:inline-flex; align-items:center; justify-content:center; width:28px; height:28px; border:1.5px solid var(--line); border-radius:50%; font-family:'Archivo'; font-weight:700; color:var(--text); cursor:pointer;">‹</span>
+          <span style="font-family:'Bebas Neue'; font-size:23px; letter-spacing:.04em; color:var(--text);">June 2026</span>
+          <span style="display:inline-flex; align-items:center; justify-content:center; width:28px; height:28px; border:1.5px solid var(--line); border-radius:50%; font-family:'Archivo'; font-weight:700; color:var(--text); cursor:pointer;">›</span>
         </div>
         <div style="display:grid; grid-template-columns:repeat(7,1fr); margin-bottom:4px;">
           <sc-for list="{{dayNames}}" as="name" hint-placeholder-count="7">
-            <span style="text-align:center; font-family:'JetBrains Mono',monospace; font-size:11px; color:#A99F8E;">{{name}}</span>
+            <span style="text-align:center; font-family:'JetBrains Mono',monospace; font-size:11px; color:var(--faint);">{{name}}</span>
           </sc-for>
         </div>
         <sc-for list="{{weeks}}" as="week" hint-placeholder-count="6">
           <div style="display:grid; grid-template-columns:repeat(7,1fr);">
             <sc-for list="{{week}}" as="day" hint-placeholder-count="7">
               <div style="position:relative; height:38px; display:flex; align-items:center; justify-content:center;">
-                <sc-if value="{{day.today}}"><div style="position:absolute; width:32px; height:32px; border-radius:50%; background:#F3C44C; border:1.5px solid #1A1714;"></div></sc-if>
+                <sc-if value="{{day.today}}"><div style="position:absolute; width:32px; height:32px; border-radius:50%; background:#F3C44C; border:1.5px solid var(--line);"></div></sc-if>
                 <span style="position:relative; font-family:'Archivo'; font-size:13px; font-weight:600; color:{{day.colorA}};">{{day.n}}</span>
               </div>
             </sc-for>
@@ -70,28 +98,61 @@
       </aside>
 
       <div>
-        <div style="font-family:'Bebas Neue'; font-size:24px; letter-spacing:.06em; color:#1A1714; margin:0 0 16px;">Upcoming Shows</div>
+        <div style="font-family:'Bebas Neue'; font-size:24px; letter-spacing:.06em; color:var(--text); margin:0 0 16px;">Upcoming Shows</div>
         <sc-for list="{{shows}}" as="show" hint-placeholder-count="12">
-          <div style="display:flex; background:#fff; border:1.5px solid #1A1714; border-radius:12px; overflow:hidden; margin-bottom:15px; box-shadow:3px 4px 0 #1A1714;" style-hover="transform:translate(-1px,-1px); box-shadow:5px 6px 0 #1A1714;">
-            <div style="position:relative; width:112px; flex-shrink:0; background:{{show.stubBgA}}; display:flex; flex-direction:column; align-items:center; justify-content:center; border-right:2px dashed #1A1714;">
-              <div style="font-family:'Bebas Neue'; font-size:34px; line-height:.9; color:{{show.stubInkA}};">{{show.time}}</div>
-              <div style="font-family:'JetBrains Mono',monospace; font-size:11px; letter-spacing:.1em; color:{{show.stubInkA}};">{{show.ampm}}</div>
-              <sc-if value="{{show.sold}}"><div style="position:absolute; bottom:13px; font-family:'JetBrains Mono',monospace; font-size:9px; letter-spacing:.12em; color:#C23B2E; border:1.5px solid #C23B2E; padding:2px 5px; border-radius:3px; transform:rotate(-8deg); background:#fff;">SOLD</div></sc-if>
-            </div>
-            <div style="flex:1; padding:15px 20px; min-width:0;">
-              <div style="display:flex; align-items:flex-start; justify-content:space-between; gap:12px;">
-                <h3 style="font-family:'Archivo'; font-weight:800; font-size:19px; color:#1A1714; margin:0;">{{show.title}}</h3>
-                <span style="flex-shrink:0; font-family:'JetBrains Mono',monospace; font-size:10px; letter-spacing:.1em; text-transform:uppercase; padding:4px 9px; border-radius:999px; background:{{show.tintA}}; color:{{show.colA}};">{{show.statusLabel}}</span>
+          <div style="background:var(--surface); border:1.5px solid var(--line); border-radius:12px; overflow:hidden; margin-bottom:15px; box-shadow:3px 4px 0 var(--shadow);">
+
+            <div onClick="{{show.onToggle}}" style="display:flex; cursor:pointer;" style-hover="background:var(--hover);">
+              <div style="position:relative; width:112px; flex-shrink:0; background:{{show.stubBgA}}; display:flex; flex-direction:column; align-items:center; justify-content:center; border-right:2px dashed var(--line);">
+                <div style="font-family:'Bebas Neue'; font-size:34px; line-height:.9; color:{{show.stubInkA}};">{{show.time}}</div>
+                <div style="font-family:'JetBrains Mono',monospace; font-size:11px; letter-spacing:.1em; color:{{show.stubInkA}};">{{show.ampm}}</div>
+                <sc-if value="{{show.sold}}"><div style="position:absolute; bottom:13px; font-family:'JetBrains Mono',monospace; font-size:9px; letter-spacing:.12em; color:#C23B2E; border:1.5px solid #C23B2E; padding:2px 5px; border-radius:3px; transform:rotate(-8deg); background:#fff;">SOLD</div></sc-if>
               </div>
-              <div style="margin:9px 0 12px; font-family:'JetBrains Mono',monospace; font-size:12px; color:#857B6D;">{{show.venue}} &nbsp;·&nbsp; {{show.cap}}</div>
-              <div style="display:flex; align-items:center; gap:14px;">
-                <div style="flex:1; height:6px; background:#EDE7DA; border-radius:999px; overflow:hidden;">
-                  <div style="height:100%; border-radius:999px; background:{{show.colA}}; width:{{show.pctStr}};"></div>
+              <div style="flex:1; padding:15px 20px; min-width:0;">
+                <div style="display:flex; align-items:flex-start; justify-content:space-between; gap:12px;">
+                  <h3 style="font-family:'Archivo'; font-weight:800; font-size:19px; color:var(--text); margin:0;">{{show.title}}</h3>
+                  <div style="display:flex; align-items:center; gap:11px; flex-shrink:0;">
+                    <span style="font-family:'JetBrains Mono',monospace; font-size:10px; letter-spacing:.1em; text-transform:uppercase; padding:4px 9px; border-radius:999px; background:{{show.tintA}}; color:{{show.colA}};">{{show.statusLabel}}</span>
+                    <span style="display:inline-flex; align-items:center; justify-content:center; width:26px; height:26px; border:1.5px solid var(--line); border-radius:50%; font-family:'Archivo'; font-weight:700; font-size:12px; color:var(--text); background:var(--surface); transition:transform .22s ease; transform:{{show.chevTransform}};">▾</span>
+                  </div>
                 </div>
-                <sc-if value="{{show.available}}"><a href="#" style="flex-shrink:0; font-family:'Archivo'; font-weight:700; font-size:13px; color:#F3C44C; background:#1A1714; padding:9px 16px; border-radius:999px; text-decoration:none;" style-hover="background:#F3C44C; color:#1A1714;">Reserve Tickets →</a></sc-if>
-                <sc-if value="{{show.sold}}"><span style="flex-shrink:0; font-family:'JetBrains Mono',monospace; font-size:11px; color:#B7AE9F;">Reservations closed</span></sc-if>
+                <div style="margin:9px 0 12px; font-family:'JetBrains Mono',monospace; font-size:12px; color:var(--muted);">{{show.venue}} &nbsp;·&nbsp; {{show.cap}} &nbsp;·&nbsp; {{show.lineupNote}}</div>
+                <div style="display:flex; align-items:center; gap:14px;">
+                  <div style="flex:1; height:6px; background:var(--track); border-radius:999px; overflow:hidden;">
+                    <div style="height:100%; border-radius:999px; background:{{show.colA}}; width:{{show.pctStr}};"></div>
+                  </div>
+                  <sc-if value="{{show.available}}"><a href="Reserve.dc.html" onClick="{{stopProp}}" style="flex-shrink:0; font-family:'Archivo'; font-weight:700; font-size:13px; color:var(--on-solid); background:var(--solid); padding:9px 16px; border-radius:999px; text-decoration:none;" style-hover="background:#F3C44C; color:#1A1714;">Reserve Tickets →</a></sc-if>
+                  <sc-if value="{{show.sold}}"><span style="flex-shrink:0; font-family:'JetBrains Mono',monospace; font-size:11px; color:var(--faint);">Reservations closed</span></sc-if>
+                </div>
               </div>
             </div>
+
+            <sc-if value="{{show.isOpen}}">
+              <div style="border-top:2px dashed var(--line); background:var(--bg); padding:18px 22px 20px; animation:lineupIn .22s ease;">
+                <div style="font-family:'JetBrains Mono',monospace; font-size:10px; letter-spacing:.16em; text-transform:uppercase; color:#9A7B1E; margin-bottom:14px;">{{show.lineupHeading}}</div>
+                <sc-if value="{{show.hasLineup}}">
+                  <sc-for list="{{show.lineup}}" as="comic" hint-placeholder-count="3">
+                    <div style="display:flex; align-items:flex-start; gap:14px; padding:11px 0; border-bottom:1px solid var(--track);">
+                      <div style="width:46px; height:46px; flex-shrink:0; border-radius:50%; background:{{comic.avBg}}; border:1.5px solid var(--line); display:flex; align-items:center; justify-content:center; font-family:'Bebas Neue'; font-size:20px; letter-spacing:.02em; color:{{comic.avInk}}; box-shadow:2px 2px 0 var(--shadow);">{{comic.initials}}</div>
+                      <div style="min-width:0; padding-top:2px;">
+                        <div style="font-family:'Archivo'; font-weight:800; font-size:16px; color:var(--text);">{{comic.name}}</div>
+                        <div style="font-family:'Archivo'; font-weight:400; font-size:13px; line-height:1.5; color:var(--muted); margin-top:2px;">{{comic.credits}}</div>
+                      </div>
+                    </div>
+                  </sc-for>
+                </sc-if>
+                <sc-if value="{{show.noLineup}}">
+                  <div style="display:flex; align-items:center; gap:12px; padding:8px 0 4px;">
+                    <span style="display:inline-flex; align-items:center; justify-content:center; width:34px; height:34px; border-radius:50%; border:1.5px dashed var(--faint); font-family:'Archivo'; font-size:16px; color:var(--faint);">?</span>
+                    <div>
+                      <div style="font-family:'Archivo'; font-weight:800; font-size:15px; color:var(--text);">Lineup not announced yet</div>
+                      <div style="font-family:'JetBrains Mono',monospace; font-size:11px; color:var(--faint); margin-top:2px;">Acts are usually posted the morning of the show.</div>
+                    </div>
+                  </div>
+                </sc-if>
+              </div>
+            </sc-if>
+
           </div>
         </sc-for>
       </div>
@@ -101,8 +162,8 @@
 
 <!-- ============ THE MARQUEE — CONDENSED ============ -->
 <div style="position:absolute; left:1400px; top:0; width:1320px;">
-  <div data-drags-parent="1" style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:.18em; text-transform:uppercase; color:#4b4438; margin-bottom:14px;">The Marquee — Condensed (whole night visible)</div>
-  <div style="background:#FBF6EC; border-radius:14px; overflow:hidden; box-shadow:0 30px 70px -22px rgba(0,0,0,.4); border:1px solid rgba(0,0,0,.06);">
+  <div data-drags-parent="1" style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:.18em; text-transform:uppercase; color:var(--muted); margin-bottom:14px;">The Marquee — Condensed · click a row for the lineup</div>
+  <div style="background:var(--bg); border-radius:14px; overflow:hidden; box-shadow:0 30px 70px -22px rgba(0,0,0,.4); border:1px solid rgba(0,0,0,.06);">
 
     <div style="background:#F3C44C; padding:16px 40px; display:flex; align-items:center; justify-content:space-between;">
       <div style="display:flex; align-items:baseline; gap:11px;">
@@ -122,29 +183,29 @@
     <div style="display:flex; align-items:flex-end; justify-content:space-between; padding:26px 40px 14px; gap:24px;">
       <div>
         <div style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:.2em; text-transform:uppercase; color:#9A7B1E;">Sunday · June 28, 2026</div>
-        <h1 style="font-family:'Bebas Neue'; font-size:46px; line-height:.9; letter-spacing:.01em; color:#1A1714; margin:6px 0 0;">Tonight at the Cellar</h1>
+        <h1 style="font-family:'Bebas Neue'; font-size:46px; line-height:.9; letter-spacing:.01em; color:var(--text); margin:6px 0 0;">Tonight at the Cellar</h1>
       </div>
-      <div style="font-family:'Archivo'; font-size:14px; color:#6B6357; white-space:nowrap; padding-bottom:4px;">12 shows · <span style="color:#1E8E4E; font-weight:700;">8 available</span></div>
+      <div style="font-family:'Archivo'; font-size:14px; color:var(--muted); white-space:nowrap; padding-bottom:4px;">12 shows · <span style="color:#1E8E4E; font-weight:700;">8 available</span></div>
     </div>
 
     <div style="display:grid; grid-template-columns:256px 1fr; gap:30px; padding:10px 40px 40px; align-items:start;">
 
-      <aside style="background:#fff; border:1.5px solid #1A1714; border-radius:14px; padding:16px 16px 16px; box-shadow:4px 5px 0 #1A1714;">
+      <aside style="background:var(--surface); border:1.5px solid var(--line); border-radius:14px; padding:16px 16px 16px; box-shadow:4px 5px 0 var(--shadow);">
         <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:12px;">
-          <span style="display:inline-flex; align-items:center; justify-content:center; width:26px; height:26px; border:1.5px solid #1A1714; border-radius:50%; font-family:'Archivo'; font-weight:700; cursor:pointer;">‹</span>
-          <span style="font-family:'Bebas Neue'; font-size:22px; letter-spacing:.04em; color:#1A1714;">June 2026</span>
-          <span style="display:inline-flex; align-items:center; justify-content:center; width:26px; height:26px; border:1.5px solid #1A1714; border-radius:50%; font-family:'Archivo'; font-weight:700; cursor:pointer;">›</span>
+          <span style="display:inline-flex; align-items:center; justify-content:center; width:26px; height:26px; border:1.5px solid var(--line); border-radius:50%; font-family:'Archivo'; font-weight:700; color:var(--text); cursor:pointer;">‹</span>
+          <span style="font-family:'Bebas Neue'; font-size:22px; letter-spacing:.04em; color:var(--text);">June 2026</span>
+          <span style="display:inline-flex; align-items:center; justify-content:center; width:26px; height:26px; border:1.5px solid var(--line); border-radius:50%; font-family:'Archivo'; font-weight:700; color:var(--text); cursor:pointer;">›</span>
         </div>
         <div style="display:grid; grid-template-columns:repeat(7,1fr); margin-bottom:2px;">
           <sc-for list="{{dayNames}}" as="name" hint-placeholder-count="7">
-            <span style="text-align:center; font-family:'JetBrains Mono',monospace; font-size:10px; color:#A99F8E;">{{name}}</span>
+            <span style="text-align:center; font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--faint);">{{name}}</span>
           </sc-for>
         </div>
         <sc-for list="{{weeks}}" as="week" hint-placeholder-count="6">
           <div style="display:grid; grid-template-columns:repeat(7,1fr);">
             <sc-for list="{{week}}" as="day" hint-placeholder-count="7">
               <div style="position:relative; height:32px; display:flex; align-items:center; justify-content:center;">
-                <sc-if value="{{day.today}}"><div style="position:absolute; width:28px; height:28px; border-radius:50%; background:#F3C44C; border:1.5px solid #1A1714;"></div></sc-if>
+                <sc-if value="{{day.today}}"><div style="position:absolute; width:28px; height:28px; border-radius:50%; background:#F3C44C; border:1.5px solid var(--line);"></div></sc-if>
                 <span style="position:relative; font-family:'Archivo'; font-size:12px; font-weight:600; color:{{day.colorA}};">{{day.n}}</span>
               </div>
             </sc-for>
@@ -153,32 +214,55 @@
       </aside>
 
       <div>
-        <div style="display:grid; grid-template-columns:68px 1fr 116px 94px 120px; gap:16px; align-items:center; padding:0 14px 8px 7px;">
+        <div style="display:grid; grid-template-columns:68px 1fr 116px 94px 120px 26px; gap:16px; align-items:center; padding:0 14px 8px 7px;">
           <span></span>
-          <span style="font-family:'JetBrains Mono',monospace; font-size:10px; letter-spacing:.14em; text-transform:uppercase; color:#A99F8E;">Show</span>
-          <span style="font-family:'JetBrains Mono',monospace; font-size:10px; letter-spacing:.14em; text-transform:uppercase; color:#A99F8E;">Seats</span>
-          <span style="justify-self:center; font-family:'JetBrains Mono',monospace; font-size:10px; letter-spacing:.14em; text-transform:uppercase; color:#A99F8E;">Status</span>
+          <span style="font-family:'JetBrains Mono',monospace; font-size:10px; letter-spacing:.14em; text-transform:uppercase; color:var(--faint);">Show</span>
+          <span style="font-family:'JetBrains Mono',monospace; font-size:10px; letter-spacing:.14em; text-transform:uppercase; color:var(--faint);">Seats</span>
+          <span style="justify-self:center; font-family:'JetBrains Mono',monospace; font-size:10px; letter-spacing:.14em; text-transform:uppercase; color:var(--faint);">Status</span>
+          <span></span>
           <span></span>
         </div>
         <sc-for list="{{shows}}" as="show" hint-placeholder-count="12">
-          <div style="display:grid; grid-template-columns:68px 1fr 116px 94px 120px; gap:16px; align-items:center; background:#fff; border:1.5px solid #1A1714; border-radius:10px; padding:7px 14px 7px 7px; margin-bottom:9px; box-shadow:2px 3px 0 #1A1714;" style-hover="transform:translate(-1px,-1px); box-shadow:4px 5px 0 #1A1714;">
-            <div style="text-align:center; background:{{show.stubBgA}}; border:1.5px solid #1A1714; border-radius:7px; padding:5px 0;">
-              <div style="font-family:'Bebas Neue'; font-size:21px; line-height:.95; color:{{show.stubInkA}};">{{show.time}}</div>
-              <div style="font-family:'JetBrains Mono',monospace; font-size:9px; color:{{show.stubInkA}};">{{show.ampm}}</div>
+          <div style="background:var(--surface); border:1.5px solid var(--line); border-radius:10px; overflow:hidden; margin-bottom:9px; box-shadow:2px 3px 0 var(--shadow);">
+            <div onClick="{{show.onToggle}}" style="display:grid; grid-template-columns:68px 1fr 116px 94px 120px 26px; gap:16px; align-items:center; padding:7px 14px 7px 7px; cursor:pointer;" style-hover="background:var(--hover);">
+              <div style="text-align:center; background:{{show.stubBgA}}; border:1.5px solid var(--line); border-radius:7px; padding:5px 0;">
+                <div style="font-family:'Bebas Neue'; font-size:21px; line-height:.95; color:{{show.stubInkA}};">{{show.time}}</div>
+                <div style="font-family:'JetBrains Mono',monospace; font-size:9px; color:{{show.stubInkA}};">{{show.ampm}}</div>
+              </div>
+              <div style="min-width:0;">
+                <div style="font-family:'Archivo'; font-weight:700; font-size:15px; color:var(--text); white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">{{show.title}}</div>
+                <div style="font-family:'JetBrains Mono',monospace; font-size:11px; color:var(--muted); white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">{{show.venue}} · {{show.lineupNote}}</div>
+              </div>
+              <div>
+                <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--muted); margin-bottom:4px;">{{show.cap}}</div>
+                <div style="height:5px; background:var(--track); border-radius:999px; overflow:hidden;"><div style="height:100%; border-radius:999px; background:{{show.colA}}; width:{{show.pctStr}};"></div></div>
+              </div>
+              <span style="justify-self:center; font-family:'JetBrains Mono',monospace; font-size:9px; letter-spacing:.06em; text-transform:uppercase; padding:3px 8px; border-radius:999px; background:{{show.tintA}}; color:{{show.colA}}; white-space:nowrap;">{{show.statusLabel}}</span>
+              <div style="justify-self:end;">
+                <sc-if value="{{show.available}}"><a href="Reserve.dc.html" onClick="{{stopProp}}" style="font-family:'Archivo'; font-weight:700; font-size:12px; color:var(--on-solid); background:var(--solid); padding:8px 14px; border-radius:999px; text-decoration:none; white-space:nowrap;" style-hover="background:#F3C44C; color:#1A1714;">Reserve →</a></sc-if>
+                <sc-if value="{{show.sold}}"><span style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--faint); white-space:nowrap;">Closed</span></sc-if>
+              </div>
+              <span style="justify-self:center; font-family:'Archivo'; font-weight:700; font-size:12px; color:var(--text); transition:transform .22s ease; transform:{{show.chevTransform}};">▾</span>
             </div>
-            <div style="min-width:0;">
-              <div style="font-family:'Archivo'; font-weight:700; font-size:15px; color:#1A1714; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">{{show.title}}</div>
-              <div style="font-family:'JetBrains Mono',monospace; font-size:11px; color:#857B6D; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">{{show.venue}}</div>
-            </div>
-            <div>
-              <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:#857B6D; margin-bottom:4px;">{{show.cap}}</div>
-              <div style="height:5px; background:#EDE7DA; border-radius:999px; overflow:hidden;"><div style="height:100%; border-radius:999px; background:{{show.colA}}; width:{{show.pctStr}};"></div></div>
-            </div>
-            <span style="justify-self:center; font-family:'JetBrains Mono',monospace; font-size:9px; letter-spacing:.06em; text-transform:uppercase; padding:3px 8px; border-radius:999px; background:{{show.tintA}}; color:{{show.colA}}; white-space:nowrap;">{{show.statusLabel}}</span>
-            <div style="justify-self:end;">
-              <sc-if value="{{show.available}}"><a href="#" style="font-family:'Archivo'; font-weight:700; font-size:12px; color:#F3C44C; background:#1A1714; padding:8px 14px; border-radius:999px; text-decoration:none; white-space:nowrap;" style-hover="background:#F3C44C; color:#1A1714;">Reserve →</a></sc-if>
-              <sc-if value="{{show.sold}}"><span style="font-family:'JetBrains Mono',monospace; font-size:10px; color:#B7AE9F; white-space:nowrap;">Closed</span></sc-if>
-            </div>
+
+            <sc-if value="{{show.isOpen}}">
+              <div style="border-top:1.5px dashed var(--line); background:var(--bg); padding:14px 16px 15px; animation:lineupIn .22s ease;">
+                <div style="font-family:'JetBrains Mono',monospace; font-size:10px; letter-spacing:.16em; text-transform:uppercase; color:#9A7B1E; margin-bottom:11px;">{{show.lineupHeading}}</div>
+                <sc-if value="{{show.hasLineup}}">
+                  <div style="display:flex; flex-wrap:wrap; gap:9px;">
+                    <sc-for list="{{show.lineup}}" as="comic" hint-placeholder-count="3">
+                      <div style="display:flex; align-items:center; gap:9px; background:var(--surface); border:1.5px solid var(--line); border-radius:999px; padding:5px 14px 5px 5px; box-shadow:1.5px 2px 0 var(--shadow);">
+                        <div style="width:30px; height:30px; flex-shrink:0; border-radius:50%; background:{{comic.avBg}}; border:1.5px solid var(--line); display:flex; align-items:center; justify-content:center; font-family:'Bebas Neue'; font-size:14px; color:{{comic.avInk}};">{{comic.initials}}</div>
+                        <span style="font-family:'Archivo'; font-weight:700; font-size:13px; color:var(--text); white-space:nowrap;">{{comic.name}}</span>
+                      </div>
+                    </sc-for>
+                  </div>
+                </sc-if>
+                <sc-if value="{{show.noLineup}}">
+                  <div style="font-family:'Archivo'; font-weight:600; font-size:13px; color:var(--faint);">No acts announced yet — usually posted the morning of the show.</div>
+                </sc-if>
+              </div>
+            </sc-if>
           </div>
         </sc-for>
       </div>
@@ -188,7 +272,44 @@
 </x-dc>
 <script type="text/x-dc" data-dc-script>
 class Component extends DCLogic {
+  state = { open: { 1: true } };
+
+  toggle(i) {
+    this.setState(s => {
+      const open = Object.assign({}, s.open);
+      open[i] = !open[i];
+      return { open };
+    });
+  }
+
   renderVals() {
+    const pool = [
+      ['Joe List', 'Writer & star of "Fourth of July", from The Tonight Show, Netflix special'],
+      ['Petey DeAbreu', "HBO: That Damn Michael Che Show, NPR: Wait Wait...Don't Tell Me"],
+      ['Ian Lara', 'HBO special Romantic Comedy, Comedy Central Half-Hour, The Tonight Show'],
+      ['Lucas Zelnick', 'Comedy Central, Netflix Is A Joke, Amazon Prime Moontower Fest'],
+      ['Winston Hodges', "Netflix, Don't Tell Comedy"],
+      ['Philipp Kostelecky', 'BBC, Comedy Central, Comic Relief, Funny New Faces'],
+      ['Yamaneika Saunders', 'Writers Guild Award Winner, The Tonight Show, Comedy Central Presents'],
+      ['Sam Morril', 'Netflix "Same Time Tomorrow", The Tonight Show, Half Hour'],
+      ['Sheng Wang', 'Netflix "Sweet and Juicy", Fresh Off the Boat'],
+      ['Gary Vider', 'The Tonight Show, Comedy Central, Last Comic Standing'],
+      ['Nikki Glaser', 'HBO, Comedy Central Roast, The Golden Globes'],
+      ['Colin Quinn', 'Trainwreck, SNL, HBO "Long Story Short"'],
+    ];
+    const initials = (n) => n.split(' ').map(w => w[0]).slice(0, 2).join('').toUpperCase();
+    const mkComic = (idx) => {
+      const [name, credits] = pool[idx % pool.length];
+      const dark = idx % 2 === 1;
+      return {
+        name, credits, initials: initials(name),
+        avBg: dark ? '#1A1714' : '#F3C44C',
+        avInk: dark ? '#F3C44C' : '#1A1714',
+      };
+    };
+    // how many acts each show has (0 = no lineup announced)
+    const counts = [3, 6, 0, 4, 4, 6, 0, 4, 4, 5, 3, 4];
+
     const raw = [
       ['1:30','PM','Brunch Show, MacDougal St','MacDougal St',176,190],
       ['6:00','PM','Village Underground','Village Underground',223,300],
@@ -203,25 +324,32 @@ class Component extends DCLogic {
       ['10:30','PM','Fat Black Pussycat Bar','Fat Black Pussycat',21,110],
       ['11:30','PM','MacDougal St.','MacDougal St',163,180],
     ];
-    const shows = raw.map(([time, ampm, title, venue, cur, max]) => {
+    const shows = raw.map(([time, ampm, title, venue, cur, max], i) => {
       const pct = Math.round((cur / max) * 100);
       const sold = cur >= max;
       const fast = !sold && pct >= 85;
-      const left = max - cur;
+      const cnt = counts[i];
+      const lineup = [];
+      for (let k = 0; k < cnt; k++) lineup.push(mkComic(i * 3 + k));
+      const isOpen = !!this.state.open[i];
       return {
         time, ampm, title, venue,
         cap: cur + ' / ' + max,
         pct, pctStr: Math.min(pct, 100) + '%',
         sold, available: !sold, fast,
-        showSeats: fast,
-        seatsLeft: left + ' seats left',
         statusLabel: sold ? 'Sold Out' : fast ? 'Selling Fast' : 'Available',
         colA: sold ? '#C23B2E' : fast ? '#C0780F' : '#1E8E4E',
-        colB: sold ? '#FF6B5B' : fast ? '#F0B23D' : '#5BD08A',
         tintA: sold ? '#F7E4E1' : fast ? '#F8EDD9' : '#E6F1E9',
         stubBgA: sold ? '#E9E3D6' : '#F3C44C',
         stubInkA: sold ? '#A89F90' : '#1A1714',
-        timeColB: sold ? '#7A7165' : '#F3C44C',
+        lineup,
+        hasLineup: cnt > 0,
+        noLineup: cnt === 0,
+        lineupNote: cnt > 0 ? (cnt + ' comics') : 'lineup TBA',
+        lineupHeading: cnt > 0 ? ("Tonight's Lineup · " + cnt + " acts") : 'Lineup',
+        isOpen,
+        chevTransform: isOpen ? 'rotate(180deg)' : 'rotate(0deg)',
+        onToggle: () => this.toggle(i),
       };
     });
 
@@ -236,14 +364,16 @@ class Component extends DCLogic {
         const today = idx === 28;
         row.push({
           n, today, muted,
-          colorA: today ? '#1A1714' : muted ? '#BCB4A4' : '#26221C',
-          colorB: today ? '#161310' : muted ? '#5C544B' : '#E7E1D5',
+          colorA: today ? '#1A1714' : muted ? 'var(--faint)' : 'var(--text)',
         });
       }
       weeks.push(row);
     }
 
-    return { shows, weeks, dayNames: ['S','M','T','W','T','F','S'] };
+    return {
+      shows, weeks, dayNames: ['S','M','T','W','T','F','S'],
+      stopProp: (e) => e.stopPropagation(),
+    };
   }
 }
 </script>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,12 +97,15 @@ importers:
       '@preact/preset-vite':
         specifier: ^2.10.2
         version: 2.10.5(@babel/core@7.29.7)(preact@10.29.3)(rollup@4.62.2)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@tailwindcss/forms':
-        specifier: ^0.5.11
-        version: 0.5.11(tailwindcss@4.3.1)
       '@tailwindcss/postcss':
         specifier: ^4.1.18
         version: 4.3.1
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.62.1
+        version: 8.62.1(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.62.1
+        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       ejs:
         specifier: ^4.0.1
         version: 4.0.1
@@ -1687,11 +1690,6 @@ packages:
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
-  '@tailwindcss/forms@0.5.11':
-    resolution: {integrity: sha512-h9wegbZDPurxG22xZSoWtdzc41/OlNEUQERNqI/0fOwa2aVlWGu7C35E/x6LDyD3lgtztFSSjKZyuVM0hxhbgA==}
-    peerDependencies:
-      tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1'
-
   '@tailwindcss/node@4.3.1':
     resolution: {integrity: sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==}
 
@@ -1838,6 +1836,65 @@ packages:
 
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
+
+  '@typescript-eslint/eslint-plugin@8.62.1':
+    resolution: {integrity: sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.62.1
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.62.1':
+    resolution: {integrity: sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.62.1':
+    resolution: {integrity: sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.62.1':
+    resolution: {integrity: sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.62.1':
+    resolution: {integrity: sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.62.1':
+    resolution: {integrity: sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.62.1':
+    resolution: {integrity: sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.62.1':
+    resolution: {integrity: sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.62.1':
+    resolution: {integrity: sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.62.1':
+    resolution: {integrity: sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@wallet-standard/app@1.1.1':
     resolution: {integrity: sha512-WDGwoByhP5gwHH01r5EaLgQdLVkACPCdOMQhmhn8rsm10h/siSgTorShzBxrn0ExSPof+Lu+C3TfgqBrPa1xoQ==}
@@ -2020,6 +2077,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   base-x@3.0.11:
     resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
 
@@ -2055,6 +2116,10 @@ packages:
 
   brace-expansion@2.1.1:
     resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2635,6 +2700,10 @@ packages:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2982,6 +3051,10 @@ packages:
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
   image-size@1.2.1:
@@ -3503,9 +3576,9 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  mini-svg-data-uri@1.4.4:
-    resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
-    hasBin: true
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
@@ -4246,6 +4319,12 @@ packages:
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -6244,11 +6323,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tailwindcss/forms@0.5.11(tailwindcss@4.3.1)':
-    dependencies:
-      mini-svg-data-uri: 1.4.4
-      tailwindcss: 4.3.1
-
   '@tailwindcss/node@4.3.1':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -6372,6 +6446,97 @@ snapshots:
   '@types/yargs@17.0.35':
     dependencies:
       '@types/yargs-parser': 21.0.3
+
+  '@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.62.1
+      '@typescript-eslint/type-utils': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.62.1
+      eslint: 9.39.4(jiti@2.7.0)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.62.1
+      '@typescript-eslint/types': 8.62.1
+      '@typescript-eslint/typescript-estree': 8.62.1(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.62.1
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.7.0)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.62.1(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.62.1
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.62.1':
+    dependencies:
+      '@typescript-eslint/types': 8.62.1
+      '@typescript-eslint/visitor-keys': 8.62.1
+
+  '@typescript-eslint/tsconfig-utils@8.62.1(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.62.1
+      '@typescript-eslint/typescript-estree': 8.62.1(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.7.0)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.62.1': {}
+
+  '@typescript-eslint/typescript-estree@8.62.1(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.62.1(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.62.1
+      '@typescript-eslint/visitor-keys': 8.62.1
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.5
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
+      '@typescript-eslint/scope-manager': 8.62.1
+      '@typescript-eslint/types': 8.62.1
+      '@typescript-eslint/typescript-estree': 8.62.1(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.62.1':
+    dependencies:
+      '@typescript-eslint/types': 8.62.1
+      eslint-visitor-keys: 5.0.1
 
   '@wallet-standard/app@1.1.1':
     dependencies:
@@ -6578,6 +6743,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   base-x@3.0.11:
     dependencies:
       safe-buffer: 5.2.1
@@ -6622,6 +6789,10 @@ snapshots:
   brace-expansion@2.1.1:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.7:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -7274,6 +7445,8 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
+  eslint-visitor-keys@5.0.1: {}
+
   eslint@9.39.4(jiti@2.7.0):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
@@ -7658,6 +7831,8 @@ snapshots:
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
 
   image-size@1.2.1:
     dependencies:
@@ -8266,7 +8441,9 @@ snapshots:
 
   mime@1.6.0: {}
 
-  mini-svg-data-uri@1.4.4: {}
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
@@ -9141,6 +9318,10 @@ snapshots:
   toidentifier@1.0.1: {}
 
   tr46@0.0.3: {}
+
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
 
   tslib@2.8.1: {}
 


### PR DESCRIPTION
Complete dark-mode styling pass with compact UI improvements and design doc updates.

- Yellow shadow for calendar in dark mode only (theme.css CSS var override)
- Comedian pills in compact lineup now link to websites (matches relaxed UI)
- Replaced arbitrary Tailwind units with built-in classes (rounded-lg, px-1.75)
- Updated design docs with Phase 3 progress and refined visuals

Staging improvements to the compact view layout ahead of phase 3 feature work.