### PR TITLE
Dark mode + UI refinements + comic images in lineup

### DIFF
--- a/packages/frontend/src/pages/Home/CompactRow.tsx
+++ b/packages/frontend/src/pages/Home/CompactRow.tsx
@@ -159,7 +159,15 @@ export function CompactRow({
                   key={index}
                   className="flex items-center gap-[9px] rounded-pill border-hair border-line bg-surface py-[5px] pl-[5px] pr-3.5 shadow-[1.5px_2px_0_var(--shadow)]"
                 >
-                  <Avatar name={act.name} size={30} />
+                  {act.img ? (
+                    <img
+                      src={act.img}
+                      alt={`Image of ${act.name}`}
+                      className="size-[30px] shrink-0 rounded-full border-hair border-line bg-track object-cover"
+                    />
+                  ) : (
+                    <Avatar name={act.name} size={30} />
+                  )}
                   <a
                     href={act.website}
                     target="_blank"


### PR DESCRIPTION
## Summary

- Dark-mode theming for Clerk auth widgets and profile page
- Remove sign-in/sign-up subline text (already shown by Clerk)
- Fix dark-mode contrast: social button text and enabled status pills
- Show comic images in notification list instead of initials avatars
- Add leading-none to avatar to fix Bebas Neue baseline centering
- Mobile-responsive: collapse header (hide subtitle, tighten nav), compact row layout
- Convert Gallery and ProfileSettings imports to @/ aliases
- Round 7px corners to 8px for consistency
- Show comic images in lineup pills with fallback to avatar

All changes applied to current workspace; PR targets feature/redesign.