### PR TITLE
Mobile show card polish and UI fixes

### DIFF
--- a/packages/frontend/src/components/CalendarButton.tsx
+++ b/packages/frontend/src/components/CalendarButton.tsx
@@ -36,7 +36,7 @@ export function CalendarButton({ day, onClick }: CalendarButtonProps) {
       <span
         aria-hidden="true"
         className={clsx(
-          "absolute size-8 rounded-full transition-colors",
+          "absolute left-1/2 top-1/2 size-8 -translate-x-1/2 -translate-y-1/2 rounded-full transition-colors",
           isSelected && "bg-solid",
           isToday && !isSelected && "border-2 border-solid",
           !isToday &&
@@ -47,7 +47,7 @@ export function CalendarButton({ day, onClick }: CalendarButtonProps) {
       <time
         dateTime={day.date}
         className={clsx(
-          "relative font-sans text-[13px] font-semibold",
+          "relative grid size-8 place-items-center font-sans text-[13px] font-semibold tabular-nums",
           isSelected && "text-solid-fg",
           isToday && !isSelected && "text-text",
           !isToday && !isSelected && isCurrentMonth && "text-text",

--- a/packages/frontend/src/components/Event.tsx
+++ b/packages/frontend/src/components/Event.tsx
@@ -76,14 +76,8 @@ export function Event(props: EventItemProps) {
 
         {/* Body */}
         <div className="min-w-0 flex-1 px-5 py-4 transition-colors hover:bg-track">
-          <div className="flex items-start justify-between gap-3">
-            <h3
-              className="min-w-0 font-sans text-lead font-extrabold text-text"
-              title={description}
-            >
-              {view.title}
-            </h3>
-            <div className="flex shrink-0 items-center gap-2.5">
+          <div className="sm:flex sm:items-start sm:justify-between sm:gap-3">
+            <div className="hidden shrink-0 items-center gap-2.5 sm:order-2 sm:flex">
               <StatusPill status={view.status} className="shrink-0" />
               {view.reservable && (
                 <Link
@@ -121,6 +115,12 @@ export function Event(props: EventItemProps) {
                 />
               </button>
             </div>
+            <h3
+              className="min-w-0 font-sans text-lead font-extrabold text-text sm:order-1"
+              title={description}
+            >
+              {view.title}
+            </h3>
           </div>
 
           <div className="mb-3 mt-2.5 flex items-center gap-2">
@@ -130,24 +130,64 @@ export function Event(props: EventItemProps) {
             </p>
           </div>
 
-          <div className="flex items-center gap-3.5">
-            <div className="flex-1">
+          <div className="flex flex-col gap-2.5 sm:flex-row sm:items-center sm:gap-3.5">
+            <div className="min-w-0 flex-1">
               <ProgressBar pct={view.pct} status={view.status} />
             </div>
-            {view.reservable ? (
-              <Link
-                href={`/reservations/${timestamp}`}
-                variant="plain"
-                onClick={(e) => e.stopPropagation()}
-                className="inline-flex shrink-0 items-center rounded-pill bg-solid px-4 py-2 font-sans text-caption font-bold text-solid-fg no-underline transition hover:bg-brand hover:text-brand-fg hover:no-underline"
-              >
-                Reserve Tickets &rarr;
-              </Link>
-            ) : (
-              <span className="shrink-0 font-mono text-[11px] text-faint">
-                Reservations closed
-              </span>
-            )}
+            <div className="flex items-center justify-end gap-2">
+              <StatusPill status={view.status} className="shrink-0 sm:hidden" />
+              {view.reservable ? (
+                <Link
+                  href={`/reservations/${timestamp}`}
+                  variant="plain"
+                  onClick={(e) => e.stopPropagation()}
+                  className="inline-flex shrink-0 items-center rounded-pill bg-solid px-4 py-2 font-sans text-caption font-bold text-solid-fg no-underline transition hover:bg-brand hover:text-brand-fg hover:no-underline"
+                >
+                  Reserve Tickets &rarr;
+                </Link>
+              ) : (
+                <span className="shrink-0 font-mono text-[11px] text-faint">
+                  Reservations closed
+                </span>
+              )}
+              <div className="flex items-center gap-2 sm:hidden">
+                {view.reservable && (
+                  <Link
+                    href={reservationUrl}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    aria-label="Open reservation page in a new tab"
+                    variant="plain"
+                    onClick={(e) => e.stopPropagation()}
+                    className="grid size-8 place-items-center rounded-full border-hair border-line text-muted no-underline transition hover:bg-track hover:text-text hover:no-underline"
+                  >
+                    <ArrowTopRightOnSquareIcon
+                      className="size-4"
+                      aria-hidden="true"
+                    />
+                  </Link>
+                )}
+                <button
+                  type="button"
+                  disabled={isLineUpLoading}
+                  aria-expanded={isOpen}
+                  aria-label={isOpen ? "Hide lineup" : "Show lineup"}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onToggle();
+                  }}
+                  className="grid size-8 place-items-center rounded-full border-hair border-line text-muted outline-none transition hover:bg-track hover:text-text disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
+                >
+                  <ChevronDownIcon
+                    className={clsx(
+                      "size-4 transition-transform",
+                      isOpen && "rotate-180"
+                    )}
+                    aria-hidden="true"
+                  />
+                </button>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/packages/frontend/src/components/EventLoader.tsx
+++ b/packages/frontend/src/components/EventLoader.tsx
@@ -3,14 +3,27 @@ export function EventLoader() {
     <div className="flex animate-pulse overflow-hidden rounded-card border-hair border-line bg-surface shadow-block">
       <div className="w-28 shrink-0 border-r-2 border-dashed border-line bg-track" />
       <div className="min-w-0 flex-1 space-y-3 px-5 py-4">
-        <div className="flex items-center justify-between gap-3">
-          <div className="h-4 w-44 rounded bg-track" />
-          <div className="h-4 w-20 rounded-pill bg-track" />
+        <div className="sm:flex sm:items-start sm:justify-between sm:gap-3">
+          <div className="hidden shrink-0 items-center gap-2.5 sm:flex">
+            <div className="h-4 w-20 rounded-pill bg-track" />
+            <div className="size-8 rounded-full bg-track" />
+            <div className="size-8 rounded-full bg-track" />
+          </div>
+          <div className="h-4 w-44 rounded bg-track sm:order-1" />
         </div>
+
         <div className="h-3 w-32 rounded bg-track" />
-        <div className="flex items-center gap-3.5">
+
+        <div className="flex flex-col gap-2.5 sm:flex-row sm:items-center sm:gap-3.5">
           <div className="h-1.5 flex-1 rounded-pill bg-track" />
-          <div className="h-9 w-36 rounded-pill bg-track" />
+          <div className="flex items-center justify-end gap-2">
+            <div className="h-4 w-20 rounded-pill bg-track sm:hidden" />
+            <div className="h-9 w-36 rounded-pill bg-track" />
+            <div className="flex items-center gap-2 sm:hidden">
+              <div className="size-8 rounded-full bg-track" />
+              <div className="size-8 rounded-full bg-track" />
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -32,8 +32,8 @@ export function Header() {
 
   return (
     <>
-      <header className="flex w-full items-center justify-between bg-brand px-3 py-2.5 sm:px-10 sm:py-4">
-        <a href="/" className="flex items-baseline">
+      <header className="flex w-full items-center justify-between gap-2 bg-brand px-3 py-2.5 sm:gap-4 sm:px-10 sm:py-4">
+        <a href="/" className="shrink-0 flex items-baseline">
           <span className="font-display text-d-sm leading-none tracking-tightcap text-ink sm:text-d-md">
             COMEDY CELLAR
           </span>
@@ -41,7 +41,7 @@ export function Header() {
             EST. NYC 1981
           </span>
         </a>
-        <nav className="flex items-center gap-x-2 sm:gap-x-6">
+        <nav className="flex min-w-0 shrink items-center gap-x-1.5 sm:gap-x-6">
           {navLinks.map((item, itemIdx) => {
             const isLast = itemIdx === navLinks.length - 1;
             const isAuthAction = item.name === "Sign In" || item.name === "Sign out";
@@ -52,7 +52,7 @@ export function Header() {
                   key={itemIdx}
                   href={item.href}
                   variant="plain"
-                  className="rounded-pill bg-ink px-3 py-2 font-sans text-xs font-bold text-brand hover:bg-ink/80 sm:px-4 sm:text-sm"
+                  className="shrink-0 rounded-pill bg-ink px-2.5 py-1.5 font-sans text-xs font-bold text-brand hover:bg-ink/80 sm:px-4 sm:py-2 sm:text-sm"
                 >
                   {item.name}
                 </Link>

--- a/packages/frontend/src/components/ui/Avatar.tsx
+++ b/packages/frontend/src/components/ui/Avatar.tsx
@@ -16,7 +16,7 @@ export function Avatar({ name, img, size = 42, className }: AvatarProps) {
     return (
       <span
         className={clsx(
-          "group relative grid shrink-0 place-items-center overflow-hidden rounded-pill border-hair border-line",
+          "grid shrink-0 place-items-center overflow-hidden rounded-pill border-hair border-line",
           className,
         )}
         style={{ width: size, height: size }}
@@ -27,14 +27,6 @@ export function Avatar({ name, img, size = 42, className }: AvatarProps) {
           loading="lazy"
           className="h-full w-full object-cover"
         />
-        {/* Translucent placeholder overlay on hover */}
-        <span
-          aria-hidden="true"
-          className="absolute inset-0 grid place-items-center font-display leading-none opacity-0 transition-opacity duration-150 group-hover:opacity-80"
-          style={{ fontSize: size * 0.4, backgroundColor: bg, color: fg }}
-        >
-          {initials}
-        </span>
       </span>
     );
   }

--- a/packages/frontend/src/pages/Auth/PageWrapper.tsx
+++ b/packages/frontend/src/pages/Auth/PageWrapper.tsx
@@ -40,7 +40,7 @@ export default function PageWrapper({
 
   return (
     <div className="flex min-h-[calc(100vh-180px)] flex-col items-center justify-center px-4 py-12">
-      <div className="w-full max-w-md">
+      <div className="w-full">
         {hasHeader ? (
           <div className="mb-6 text-center">
             {eyebrow ? <Eyebrow>{eyebrow}</Eyebrow> : null}
@@ -55,7 +55,7 @@ export default function PageWrapper({
           </div>
         ) : null}
 
-        <div className="rounded-2xl border-hair border-line bg-surface px-7 pb-6 py-6 shadow-block-lg">
+        <div className="rounded-2xl border-hair border-line bg-surface px-4 py-6 pb-6 shadow-block-lg sm:px-7">
           {children}
         </div>
 

--- a/packages/frontend/src/pages/Auth/authAppearance.ts
+++ b/packages/frontend/src/pages/Auth/authAppearance.ts
@@ -22,7 +22,7 @@ export const authAppearance = {
     fontFamily: "Archivo, system-ui, sans-serif",
   },
   elements: {
-    rootBox: "w-full",
+    rootBox: "w-full max-w-full",
     cardBox: "w-full border-none! bg-transparent! p-0! shadow-none!",
     card: "border-none! bg-transparent! p-0! shadow-none!",
     header: "hidden",

--- a/packages/frontend/src/pages/Comics/ComicItem.tsx
+++ b/packages/frontend/src/pages/Comics/ComicItem.tsx
@@ -14,35 +14,14 @@ export function ComicItem({ comic }: { comic: Comic }) {
         className="flex h-full flex-col overflow-hidden rounded-card border-hair border-line bg-surface shadow-block transition-all duration-150 hover:-translate-x-px hover:-translate-y-px hover:shadow-block-lg focus:outline-none focus-visible:-translate-x-px focus-visible:-translate-y-px focus-visible:shadow-block-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
       >
         {/* Photo — falls back to the swatch + initials placeholder when comic.img is missing */}
-        <div className="group relative h-44 overflow-hidden border-b-2 border-line">
+        <div className="relative h-44 overflow-hidden border-b-2 border-line">
           {comic.img ? (
-            <>
-              <Img
-                alt={`${comic.name}'s photo`}
-                loading="lazy"
-                src={comic.img}
-                className="h-full w-full object-cover"
-              />
-              {/* Translucent placeholder overlay on hover */}
-              <div
-                className="absolute inset-0 flex items-center justify-center opacity-0 transition-opacity duration-150 group-hover:opacity-80"
-                style={{ backgroundColor: bg }}
-                aria-hidden="true"
-              >
-                <span
-                  className="font-display text-8xl leading-none tracking-[0.04em]"
-                  style={{ color: fg }}
-                >
-                  {initials}
-                </span>
-                <span
-                  className="absolute bottom-2 right-2.5 font-mono text-[8px] uppercase tracking-wider"
-                  style={{ color: fg, opacity: 0.55 }}
-                >
-                  PHOTO
-                </span>
-              </div>
-            </>
+            <Img
+              alt={`${comic.name}'s photo`}
+              loading="lazy"
+              src={comic.img}
+              className="h-full w-full object-cover"
+            />
           ) : (
             <div
               className="flex h-full items-center justify-center"

--- a/packages/frontend/src/pages/Home/CompactRow.tsx
+++ b/packages/frontend/src/pages/Home/CompactRow.tsx
@@ -54,7 +54,7 @@ export function CompactRow({
         {/* Time stub */}
         <div
           className={clsx(
-            "rounded-[8px] border-hair border-line py-[5px] text-center",
+            "flex flex-col items-center justify-center rounded-[8px] border-hair border-line py-[5px] text-center",
             view.closed ? "bg-stub" : "bg-brand"
           )}
         >


### PR DESCRIPTION
## Summary
- Reorganizes Spotlight show cards on mobile so the title stands alone, the progress bar gets its own row, and the availability badge, reserve button, external link, and lineup chevron share a bottom action row; the skeleton loader matches this layout.
- Renames view modes to "Spotlight" and "Set List", centers Set List time stubs and calendar date numbers, and removes comedian image hover overlays while keeping initials when no photo exists.
- Fixes mobile clipping in the header nav and auth pages by loosening width constraints and tightening small-screen spacing.

## Test plan
- [ ] On mobile, verify Spotlight cards show title → metadata → progress bar → action row layout
- [ ] Confirm Set List time stubs are centered and calendar dates look visually centered
- [ ] Check Comics page: no hover overlay on photos, initials still show without images
- [ ] Verify Sign In / sign-up forms and header nav are not clipped on a narrow viewport


Made with [Cursor](https://cursor.com)