### PR TITLE
Spotlight card cleanup and calendar year fixes

### DIFF
--- a/packages/frontend/src/components/Calendar.tsx
+++ b/packages/frontend/src/components/Calendar.tsx
@@ -6,6 +6,7 @@ import {
   getPreviousMonthsDates,
   getToday,
 } from "../utils/date";
+import { format } from "date-fns";
 import { useMemo, useState } from "preact/hooks";
 
 import { CalendarButton } from "./CalendarButton";
@@ -63,9 +64,10 @@ export function Calendar({ value, onChange }) {
   });
 
   const days = useMemo(() => {
-    const today = new Date();
-    today.setMonth(selectedMonth - 1);
-    const formatDate = today.toISOString().split("T")[0];
+    const formatDate = format(
+      new Date(selectedYear, selectedMonth - 1, 1),
+      "yyyy-MM-dd"
+    );
 
     const currentMonthDates = getDatesInMonth(formatDate);
     const nextMonthDates = getNextMonthsDates(formatDate);
@@ -102,7 +104,7 @@ export function Calendar({ value, onChange }) {
     }
 
     return calendarDays;
-  }, [selectedMonth, value]);
+  }, [selectedMonth, selectedYear, value]);
 
   const monthString = getMonthName(selectedMonth);
 
@@ -130,30 +132,49 @@ export function Calendar({ value, onChange }) {
     onChange(date);
   };
 
+  const handleGoToToday = () => {
+    const today = getToday();
+    const [year, month] = today.split("-").map((part) => parseInt(part, 10));
+    setSelectedYear(year);
+    setSelectedMonth(month);
+    onChange(today);
+  };
+
   const weekdayInitials = ["S", "M", "T", "W", "T", "F", "S"];
 
   return (
     <div className="calendar-dark-shadow border-hair border-line rounded-panel bg-surface p-[1.125rem] shadow-block-md">
-      <div className="mb-3.5 flex items-center justify-between">
-        <button
-          type="button"
-          onClick={handlePreviousMonth}
-          className="flex size-7 items-center justify-center rounded-full border-hair border-line text-text outline-none transition hover:bg-track focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
-        >
-          <span className="sr-only">Previous month</span>
-          <ChevronLeftIcon className="size-4" aria-hidden="true" />
-        </button>
-        <span className="font-display text-d-sm tracking-cap text-text">
-          {monthString} {selectedYear}
-        </span>
-        <button
-          type="button"
-          onClick={handleNextMonth}
-          className="flex size-7 items-center justify-center rounded-full border-hair border-line text-text outline-none transition hover:bg-track focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
-        >
-          <span className="sr-only">Next month</span>
-          <ChevronRightIcon className="size-4" aria-hidden="true" />
-        </button>
+      <div className="mb-3.5">
+        <div className="flex items-center justify-between">
+          <button
+            type="button"
+            onClick={handlePreviousMonth}
+            className="flex size-7 items-center justify-center rounded-full border-hair border-line text-text outline-none transition hover:bg-track focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
+          >
+            <span className="sr-only">Previous month</span>
+            <ChevronLeftIcon className="size-4" aria-hidden="true" />
+          </button>
+          <span className="font-display text-d-sm tracking-cap text-text">
+            {monthString} {selectedYear}
+          </span>
+          <button
+            type="button"
+            onClick={handleNextMonth}
+            className="flex size-7 items-center justify-center rounded-full border-hair border-line text-text outline-none transition hover:bg-track focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
+          >
+            <span className="sr-only">Next month</span>
+            <ChevronRightIcon className="size-4" aria-hidden="true" />
+          </button>
+        </div>
+        <div className="mt-2 flex justify-center">
+          <button
+            type="button"
+            onClick={handleGoToToday}
+            className="rounded-pill border-hair border-line px-3 py-1 font-mono text-meta uppercase tracking-wide text-muted outline-none transition hover:bg-track hover:text-text focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
+          >
+            Today
+          </button>
+        </div>
       </div>
       <div className="grid grid-cols-7">
         {weekdayInitials.map((name, index) => (

--- a/packages/frontend/src/components/Event.tsx
+++ b/packages/frontend/src/components/Event.tsx
@@ -6,7 +6,6 @@ import {
 
 import { Link } from "./Link";
 import { Act } from "./Act";
-import { StatusPill } from "./ui/StatusPill";
 import { ProgressBar } from "./ui/ProgressBar";
 import { Show, LineUp } from "../types";
 import { getShowView } from "../pages/Home/types";
@@ -78,7 +77,6 @@ export function Event(props: EventItemProps) {
         <div className="min-w-0 flex-1 px-5 py-4 transition-colors hover:bg-track">
           <div className="sm:flex sm:items-start sm:justify-between sm:gap-3">
             <div className="hidden shrink-0 items-center gap-2.5 sm:order-2 sm:flex">
-              <StatusPill status={view.status} className="shrink-0" />
               {view.reservable && (
                 <Link
                   href={reservationUrl}
@@ -130,12 +128,11 @@ export function Event(props: EventItemProps) {
             </p>
           </div>
 
-          <div className="flex flex-col gap-2.5 sm:flex-row sm:items-center sm:gap-3.5">
-            <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-3.5">
+            <div className="hidden min-w-0 flex-1 sm:block">
               <ProgressBar pct={view.pct} status={view.status} />
             </div>
-            <div className="flex items-center justify-end gap-2">
-              <StatusPill status={view.status} className="shrink-0 sm:hidden" />
+            <div className="flex flex-1 items-center justify-end gap-2 sm:flex-none">
               {view.reservable ? (
                 <Link
                   href={`/reservations/${timestamp}`}

--- a/packages/frontend/src/components/EventLoader.tsx
+++ b/packages/frontend/src/components/EventLoader.tsx
@@ -5,7 +5,6 @@ export function EventLoader() {
       <div className="min-w-0 flex-1 space-y-3 px-5 py-4">
         <div className="sm:flex sm:items-start sm:justify-between sm:gap-3">
           <div className="hidden shrink-0 items-center gap-2.5 sm:flex">
-            <div className="h-4 w-20 rounded-pill bg-track" />
             <div className="size-8 rounded-full bg-track" />
             <div className="size-8 rounded-full bg-track" />
           </div>
@@ -14,10 +13,9 @@ export function EventLoader() {
 
         <div className="h-3 w-32 rounded bg-track" />
 
-        <div className="flex flex-col gap-2.5 sm:flex-row sm:items-center sm:gap-3.5">
-          <div className="h-1.5 flex-1 rounded-pill bg-track" />
-          <div className="flex items-center justify-end gap-2">
-            <div className="h-4 w-20 rounded-pill bg-track sm:hidden" />
+        <div className="flex items-center gap-3.5">
+          <div className="hidden h-1.5 flex-1 rounded-pill bg-track sm:block" />
+          <div className="flex flex-1 items-center justify-end gap-2 sm:flex-none">
             <div className="h-9 w-36 rounded-pill bg-track" />
             <div className="flex items-center gap-2 sm:hidden">
               <div className="size-8 rounded-full bg-track" />


### PR DESCRIPTION
## Summary
- Removes the availability badge from Spotlight cards and hides the progress bar on mobile, with the skeleton loader updated to match.
- Fixes the calendar to build its grid from the selected year and month so today highlighting, date selection, and URL filtering use the correct year.
- Adds a Today button that jumps back to the current month and selects today's date.

## Test plan
- [ ] On mobile, verify Spotlight cards show no badge or progress bar; desktop still shows the progress bar
- [ ] Navigate to a future year/month and confirm clicked dates update the URL with the correct year
- [ ] Confirm only the real today gets the today ring, not the same day in other years
- [ ] Click Today and verify the calendar and show list jump to the current date


Made with [Cursor](https://cursor.com)