### PR TITLE
fix(frontend): declare @clerk/types so CI typecheck passes

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -8,6 +8,7 @@
 	},
 	"dependencies": {
 		"@clerk/clerk-js": "^5.120.0",
+		"@clerk/types": "^4.101.25",
 		"@heroicons/react": "^2.2.0",
 		"@sentry/browser": "^10.34.0",
 		"@tanstack/react-query": "^5.90.19",

--- a/packages/frontend/pnpm-lock.yaml
+++ b/packages/frontend/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@clerk/clerk-js':
         specifier: ^5.120.0
         version: 5.127.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bs58@6.0.0)(bufferutil@4.1.0)(react-dom@19.2.7(react@19.2.7))(react-native@0.86.0(@babel/core@7.29.7)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.7))(utf-8-validate@6.0.6)
+      '@clerk/types':
+        specifier: ^4.101.25
+        version: 4.101.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@heroicons/react':
         specifier: ^2.2.0
         version: 2.2.0(react@19.2.7)


### PR DESCRIPTION
## What

Adds `@clerk/types` (`^4.101.25`) as a direct dependency of `packages/frontend` and syncs the frontend lockfile.

## Why

`packages/frontend/src/hooks/useAuth.ts:2` imports `@clerk/types`, but it was never declared in `packages/frontend/package.json` (only `@clerk/clerk-js` was). It resolved **locally** only because a repo-root `pnpm install` hoisted a transitive copy that a directory walk-up could find — a phantom dependency.

CI, however, runs `pnpm install --frozen-lockfile` **inside `packages/frontend`** (its own workspace), where `@clerk/types` was not resolvable. So `pnpm exec tsc --noEmit` failed:

```
src/hooks/useAuth.ts(2,30): error TS2307: Cannot find module '@clerk/types' or its corresponding type declarations.
Process completed with exit code 2.
```

As a result the **Frontend CI workflow has failed on every run since it was added on 2026-07-02** (Lint passes, Typecheck fails, Build is skipped).

## The change

`^4.101.25` is the exact version already pulled in transitively via `@clerk/clerk-js`, so this is a zero-churn declaration — the lockfile diff is 3 added lines (the new importer entry), no version bumps, no format change.

## Verification (run in `packages/frontend`)

| Command | Before | After |
|---|---|---|
| `pnpm install --frozen-lockfile` | ✅ (but `@clerk/types` absent from top-level) | ✅ (`@clerk/types` installed as declared dep) |
| `pnpm exec eslint src` | ✅ | ✅ |
| `pnpm exec tsc --noEmit` | ❌ TS2307 in CI | ✅ exit 0 |

After the change, `@clerk/types` installs at the top level of the frontend `node_modules`, so a CI-faithful frontend-only frozen install resolves it directly.

## Scope

Dependency declaration only — no source or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014crHcUve5QDzH8yUNZ5upf)_