### PR TITLE
feat(frontend): announce new show email notifications on Updates page

### DIFF
--- a/packages/frontend/src/pages/Updates/data.ts
+++ b/packages/frontend/src/pages/Updates/data.ts
@@ -7,6 +7,11 @@ export interface Update {
 export const updates: Update[] = [
   {
     date: "July 2026",
+    title: "New Show Email Notifications",
+    text: "You can now get emailed when new shows are added! Subscribers receive an email digest whenever fresh shows hit the calendar. Turn it on with the show notification toggle in your profile settings.",
+  },
+  {
+    date: "July 2026",
     title: "Redesign",
     text: "We've given the whole site a fresh look! New vintage marquee styling, equal-height comic cards, dark mode, and other polish across every page.",
   },


### PR DESCRIPTION
## Summary
- Adds a changelog entry to the Updates page for the new-show email notification feature shipped in #62 (ShowNotificationCron).
- User-facing copy — no cron/cadence details; points users at the show notification toggle in profile settings.

## Testing
- `tsc --noEmit` in packages/frontend: 33 errors before and after this change — all pre-existing in `src/pages/Gallery/index.tsx` (ReactPortal type mismatch), zero introduced by this diff.