### PR TITLE
fix(email): brand mail as Comedy Cellar Calendar, not project name

### DIFF
--- a/packages/core/email.ts
+++ b/packages/core/email.ts
@@ -2,7 +2,7 @@ import { Resource } from "sst";
 import { SESv2Client, SendEmailCommand } from "@aws-sdk/client-sesv2";
 
 const client = new SESv2Client();
-const FromAddress = `Comedy Cellar Bot <notifications@${Resource.Email.sender}>`;
+const FromAddress = `Comedy Cellar Calendar <notifications@${Resource.Email.sender}>`;
 const AlertRecipient = Resource.AlertEmail.value;
 
 export async function sendEmail({

--- a/packages/core/emails/newShowsEmail.tsx
+++ b/packages/core/emails/newShowsEmail.tsx
@@ -271,7 +271,7 @@ export function NewShowsEmail({
                 letterSpacing: "3px",
               }}
             >
-              COMEDY CELLAR BOT
+              COMEDY CELLAR CALENDAR
             </Text>
             <Text
               style={{


### PR DESCRIPTION
## Summary
- "Comedy Cellar Bot" is the project/repo name, not user-facing branding; the site titles itself "Comedy Cellar Calendar" (packages/frontend/index.html).
- New-show email masthead: `COMEDY CELLAR BOT` → `COMEDY CELLAR CALENDAR`.
- Sender display name (`FromAddress` in packages/core/email.ts): `Comedy Cellar Bot` → `Comedy Cellar Calendar`. Note this applies to all outgoing mail, including admin alert emails.

## Testing
- String-only change; no automated backend tests exist. Grep confirms no remaining "Cellar Bot" strings in packages/.