### PR TITLE
feat(core): email AlertEmail per new show, unbatched

### DIFF
--- a/infra/api.ts
+++ b/infra/api.ts
@@ -55,9 +55,11 @@ api.route("GET /api/shows/scan", {
   link: [dbCreds.dbUrl],
 });
 
+// handleShowDetails sends per-new-show alert emails, so every route whose
+// handler ingests shows needs the email identity + AlertEmail linked
 api.route("GET /api/shows", {
   handler: `${functionDir}/shows/index.listShows`,
-  link: [dbCreds.dbUrl],
+  link: [dbCreds.dbUrl, ...Object.values(emailSecrets), email],
 });
 
 api.route("GET /api/shows/new", {
@@ -67,7 +69,7 @@ api.route("GET /api/shows/new", {
 
 api.route("GET /api/shows/{timestamp}", {
   handler: `${functionDir}/shows/index.getShow`,
-  link: [dbCreds.dbUrl],
+  link: [dbCreds.dbUrl, ...Object.values(emailSecrets), email],
 });
 
 // ---- Line Ups -----

--- a/packages/core/handleShowDetails.ts
+++ b/packages/core/handleShowDetails.ts
@@ -2,6 +2,7 @@ import { fetchShows } from "./fetchShows";
 import { createRooms } from "./models/room";
 import { createShows, Show } from "./models/show";
 import { enqueueNewShows } from "./models/newShowQueue";
+import { sendEmail } from "./email";
 
 export const handleShowDetails = async ({ date }: { date: string }) => {
   const showsData = await fetchShows(date);
@@ -32,6 +33,28 @@ export const handleShowDetails = async ({ date }: { date: string }) => {
           .map((row) => row.id);
 
         await enqueueNewShows(newUpcomingShowIds);
+
+        // Subscribers get the batched digest above; AlertEmail gets one
+        // email per brand-new show, unbatched
+        const insertedIds = new Set(
+          createShowsResult.value
+            .filter((row) => row.inserted)
+            .map((row) => row.id)
+        );
+        await Promise.allSettled(
+          shows
+            .filter((show) => insertedIds.has(show.id))
+            .map((show) =>
+              sendEmail({
+                subject: `new show! ${show.roomName ?? ""} ${show.time}`.trim(),
+                message: JSON.stringify(
+                  { date, roomName: show.roomName, ...show },
+                  null,
+                  2
+                ),
+              })
+            )
+        );
       }
     }
   } catch (e) {


### PR DESCRIPTION
## Summary
- AlertEmail now receives one email per brand-new show (no batching), sent from `handleShowDetails` — the choke point all ingestion paths share (newShowCron, syncCron, `/sync-shows`, reservation lookup, and the `GET /api/shows*` cache-through routes). Subscribers are untouched: they keep the batched digest from ShowNotificationCron.
- Subject: `new show! <room> <time>`; body is the full show JSON plus date and room name (matches the existing ops-telemetry email style).
- Uses the existing `inserted` (xmax = 0) flag from `createShows`, so only genuinely new rows trigger mail; updates never do.
- Infra: linked the SES `email` identity + `AlertEmail` secret into `GET /api/shows` and `GET /api/shows/{timestamp}` — their handlers now import `core/email`, which resolves `Resource.Email`/`Resource.AlertEmail` at module load and would crash unlinked.

## Notes
- Failures are contained: per-email `Promise.allSettled` plus the surrounding try/catch, so a SES rejection can't break ingestion.
- `show.id` is the comedycellar.com show id (it's the upsert conflict target), so matching inserted rows back to full `Show` objects by id is exact.

## Testing
- No backend test harness exists; verified by reading `createShows` return contract and esbuild syntax check. Deploy-time behavior (route links) needs an `sst deploy` to a dev stage to confirm.