### PR TITLE
feat(frontend): mark comic notifications as coming soon

### DIFF
--- a/packages/frontend/src/pages/Profile/profileSettings.tsx
+++ b/packages/frontend/src/pages/Profile/profileSettings.tsx
@@ -65,7 +65,7 @@ export function ProfileSettings() {
       <Card>
         <CardHeader>
           <h3 className="font-display text-d-sm tracking-cap text-text">
-            Comic Notifications
+            Comic Notifications (coming soon)
           </h3>
           <p className="mt-1 font-sans text-caption text-muted">
             You'll be notified when a tracked comic is added to a show. Manage


### PR DESCRIPTION
## Summary
- Profile settings "Comic Notifications" heading now reads "Comic Notifications (coming soon)" — subscriptions are stored but nothing sends comic notification emails yet.

## Testing
- packages/frontend tsc: 33 errors, all pre-existing (Gallery/index.tsx); eslint clean.