### PR TITLE
Link Email resource to GET /api/shows/new route

### DIFF
--- a/infra/api.ts
+++ b/infra/api.ts
@@ -62,9 +62,12 @@ api.route("GET /api/shows", {
   link: [dbCreds.dbUrl, ...Object.values(emailSecrets), email],
 });
 
+// listShowsLocal itself doesn't send email, but this handler file is bundled
+// together with listShows/getShow, which pull in email.ts (reads
+// Resource.Email/AlertEmail at module load), so the link is required here too.
 api.route("GET /api/shows/new", {
   handler: `${functionDir}/shows/index.listShowsLocal`,
-  link: [dbCreds.dbUrl],
+  link: [dbCreds.dbUrl, ...Object.values(emailSecrets), email],
 });
 
 api.route("GET /api/shows/{timestamp}", {


### PR DESCRIPTION
## Summary
- `GET /api/shows/new` (`listShowsLocal`) crashed on cold start with `"Email" is not linked in your sst.config.ts to comedy-cellar-bot-prod-ApiRouteKbdnnaHandlerFunction-...`
- `listShowsLocal` is bundled into the same handler file as `listShows`/`getShow` (`packages/functions/shows/index.ts`), which import `handleShowDetails` → `email.ts`
- `email.ts` reads `Resource.Email.sender` and `Resource.AlertEmail.value` at module load time, so the whole bundle needs the `Email` resource linked even though `listShowsLocal` itself never sends email
- Added `email` and `emailSecrets` to the route's `link:` array in `infra/api.ts`, matching the existing pattern on `/api/shows` and `/api/shows/{timestamp}`

## Test plan
- [ ] Deploy `prod` and confirm `GET /api/shows/new` no longer throws on cold start


---
_Generated by [Claude Code](https://claude.ai/code/session_01YJhbTzE9kWhEgp5hxkppny)_