### PR TITLE
Set default Lambda runtime to nodejs24.x

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -17,6 +17,10 @@ export default $config({
     };
   },
   async run() {
+    $transform(sst.aws.Function, (args) => {
+      args.runtime ??= "nodejs24.x";
+    });
+
     const { readdirSync } = await import("fs");
     const outputs = {};
 


### PR DESCRIPTION
## Summary
- Node 20 is EOL for AWS Lambda; this adds a global `$transform(sst.aws.Function, ...)` in `sst.config.ts` so every Lambda (all API routes in `infra/api.ts` and all three crons in `infra/cron.ts`) defaults to `nodejs24.x`, the latest supported Lambda Node runtime, without editing each function definition individually.

## Test plan
- [ ] Deploy to a personal dev stage (`pnpm dev` or scoped `sst deploy --stage=<stage>`) and confirm all handlers cold-start cleanly on Node 24
- [ ] Hit a few routes (health check, shows, reservation) to confirm no runtime-specific breakage
- [ ] Deploy to prod once dev-stage verification passes


---
_Generated by [Claude Code](https://claude.ai/code/session_0157tq1sG5cTnGdFynFeo47F)_