### PR TITLE
Pin supabase provider to explicit version

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -12,7 +12,9 @@ export default $config({
           apiToken: process.env.CLOUDFLARE_API_TOKEN,
           email: process.env.CLOUDFLARE_EMAIL,
         },
-        supabase: true
+        supabase: {
+          version: "1.9.1",
+        },
       },
     };
   },


### PR DESCRIPTION
## Summary
- `providers.supabase: true` in `sst.config.ts` is deprecated as of SST v4 (`✕ Setting providers.supabase to true is deprecated. Specify the version explicitly instead.`) — it silently resolves to whatever the latest provider version happens to be at install time, making deploys non-reproducible.
- Pins it to `1.9.1`, the current official Supabase provider on the Pulumi registry (published by Supabase).

## Test plan
- [ ] Run `sst install` on a machine with AWS credentials to re-resolve the pinned provider version
- [ ] Confirm the deprecation warning no longer appears on `sst diff`/`sst dev`/`sst deploy`
- [ ] Deploy to a personal dev stage and confirm Supabase-backed resources still resolve correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_0157tq1sG5cTnGdFynFeo47F)_