### PR TITLE
Fix supabase provider version pin

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -13,7 +13,7 @@ export default $config({
           email: process.env.CLOUDFLARE_EMAIL,
         },
         supabase: {
-          version: "1.9.1",
+          version: "1.4.1",
         },
       },
     };


### PR DESCRIPTION
## Summary
- `main` currently pins `providers.supabase.version` to `1.9.1` (from PR #77), which caused `sst dev`/`install` to fail with `provider supabase not found`.
- Root cause: SST doesn't consume the official Pulumi-registry `supabase` package (schema version `1.9.1`) — it republishes its own bridged provider under the `@sst-provider/supabase` npm scope, which only has versions `0.0.3` and `1.4.1` published. `1.9.1` doesn't exist there.
- Fixes the pin to `1.4.1`, the latest version actually available in `@sst-provider/supabase`.

## Test plan
- [ ] Run `sst dev` or `sst install` on a machine with AWS credentials and confirm the provider resolves without error
- [ ] Deploy to a personal dev stage and confirm Supabase-backed resources still work


---
_Generated by [Claude Code](https://claude.ai/code/session_0157tq1sG5cTnGdFynFeo47F)_