### PR TITLE
Update reservation URL to use internal reservation page

### DIFF
--- a/packages/core/emails/newShowsEmail.tsx
+++ b/packages/core/emails/newShowsEmail.tsx
@@ -23,8 +23,6 @@ import { formatInTimeZone } from "date-fns-tz";
 
 const TIME_ZONE = "America/New_York";
 const SITE_URL = "https://comedycellar.mafz.al";
-// Keep readers on our site: link to our own reservation page
-// (/reservations/:timestamp) rather than out to comedycellar.com.
 const RESERVATION_URL = `${SITE_URL}/reservations/`;
 const MANAGE_URL = `${SITE_URL}/profile`;
 

--- a/packages/core/emails/newShowsEmail.tsx
+++ b/packages/core/emails/newShowsEmail.tsx
@@ -22,8 +22,10 @@ import { formatInTimeZone } from "date-fns-tz";
 // Keep it free of db/sst imports so it can be rendered and previewed offline.
 
 const TIME_ZONE = "America/New_York";
-const RESERVATION_URL = "https://www.comedycellar.com/reservation/?showid=";
 const SITE_URL = "https://comedycellar.mafz.al";
+// Keep readers on our site: link to our own reservation page
+// (/reservations/:timestamp) rather than out to comedycellar.com.
+const RESERVATION_URL = `${SITE_URL}/reservations/`;
 const MANAGE_URL = `${SITE_URL}/profile`;
 
 // Brand tokens borrowed from packages/frontend/src/theme.css


### PR DESCRIPTION
## Summary
Updated the reservation URL in the new shows email to link to an internal reservation page instead of redirecting users to comedycellar.com.

## Key Changes
- Changed `RESERVATION_URL` from `https://www.comedycellar.com/reservation/?showid=` to `${SITE_URL}/reservations/`
- Moved `RESERVATION_URL` constant definition after `SITE_URL` to maintain proper dependency order
- Added clarifying comments explaining the rationale: keeping readers on our site rather than redirecting externally

## Implementation Details
The reservation URL now points to the internal `/reservations/:timestamp` route on our site (comedycellar.mafz.al) instead of the external comedycellar.com domain. This improves user experience by keeping traffic within our application and allows for better control over the reservation flow.

https://claude.ai/code/session_01UpbVBqHsdJyLgVMbGNJZTT