### PR TITLE
Add andrewcboryk@gmail.com to comic notification cron allowlist

### DIFF
--- a/packages/functions/cron/comicNotificationCron.ts
+++ b/packages/functions/cron/comicNotificationCron.ts
@@ -20,6 +20,7 @@ const IS_CRON = process.env.IS_CRON === "1";
 // it's proven out, then widen or remove it.
 const ALLOWED_EMAILS: string[] = [
   "mafzal91@gmail.com",
+  "andrewcboryk@gmail.com",
 ];
 const ALLOWED_EMAILS_SET = new Set(
   ALLOWED_EMAILS.map((email) => email.toLowerCase())


### PR DESCRIPTION
## Summary
Added a new email address to the allowed emails list for the comic notification cron job.

## Changes
- Added `andrewcboryk@gmail.com` to the `ALLOWED_EMAILS` array in the comic notification cron configuration

## Details
This change expands the allowlist of email addresses that can receive comic notifications from the cron job. The new email is added to the existing allowlist which currently contains `mafzal91@gmail.com`. The email is automatically normalized to lowercase when added to the `ALLOWED_EMAILS_SET` for case-insensitive comparison.

https://claude.ai/code/session_01YR9AJB68uJx2B2ucX2cf4a