### PR TITLE
Remove size parameter from avatar image URLs

### DIFF
--- a/packages/frontend/src/components/ui/Avatar.tsx
+++ b/packages/frontend/src/components/ui/Avatar.tsx
@@ -1,5 +1,6 @@
 import clsx from "clsx";
 import { getInitials, getSwatch } from "../../utils/swatches";
+import { removeSizeFromUrl } from "../../utils/helpers";
 
 export interface AvatarProps {
   name: string;
@@ -22,7 +23,7 @@ export function Avatar({ name, img, size = 42, className }: AvatarProps) {
         style={{ width: size, height: size }}
       >
         <img
-          src={img}
+          src={removeSizeFromUrl(img)}
           alt={`${name}'s photo`}
           loading="lazy"
           className="h-full w-full object-cover"


### PR DESCRIPTION
## Summary
Updated the Avatar component to strip size parameters from image URLs before rendering, ensuring consistent image loading behavior.

## Key Changes
- Added import of `removeSizeFromUrl` utility function from helpers
- Modified the Avatar component to process the `img` prop through `removeSizeFromUrl()` before passing it to the `src` attribute

## Implementation Details
The change ensures that any size-related query parameters or URL modifications are removed from avatar image URLs before they are loaded. This likely addresses issues with image caching, CDN behavior, or URL consistency where size parameters in the URL could cause unexpected behavior or duplicate requests.

https://claude.ai/code/session_01RhaHY1LRsr5LopnNAdVVQW