### PR TITLE
Add act image support to LineUp avatar display

### DIFF
--- a/packages/frontend/src/pages/Reservations/ShowDetails.tsx
+++ b/packages/frontend/src/pages/Reservations/ShowDetails.tsx
@@ -63,7 +63,7 @@ function LineUpDetails(props: { lineUp: LineUp }) {
           className="-mr-[7px] inline-flex"
         >
           <span className="sr-only">{act.name}</span>
-          <Avatar name={act.name} size={30} />
+          <Avatar name={act.name} img={act.img} size={30} />
         </span>
       ))}
     </div>


### PR DESCRIPTION
## Summary
Updated the LineUp details component to display act images in avatars when available.

## Changes
- Modified `Avatar` component usage in `LineUpDetails` to pass the `img` prop from the act object
- This allows avatars to display custom images for acts instead of relying solely on name-based avatar generation

## Implementation Details
The `Avatar` component now receives both the act name and image URL, enabling richer visual representation of lineup acts with their associated images.

https://claude.ai/code/session_01EcyKgbPrVsbisH38MbUQKt