### PR TITLE
Add notification frequency settings for global digests

### DIFF
--- a/docs/email-notification-frequency.md
+++ b/docs/email-notification-frequency.md
@@ -1,0 +1,155 @@
+# Email Notification Frequency
+
+How the "how often should we email you" setting works for the two global
+subscriber emails.
+
+## What this is
+
+Signed-in users can opt in to two **global** emails:
+
+- **New Show Alerts** — a heads-up when new shows are added.
+- **New Comic Alerts** — a heads-up when a comic new to the Comedy Cellar joins a lineup.
+
+For each of these, a user can choose **how often** they want to hear from us:
+
+- **Immediately** — as soon as there's something to announce.
+- **Weekly** — at most one digest every 7 days.
+- **Monthly** — at most one digest every 30 days.
+
+This setting does **not** apply to the "a comic I follow was booked" emails. Those
+are event-driven and unchanged.
+
+> Note: the UI only offers Immediately / Weekly / Monthly, but the backend stores
+> the cadence as an arbitrary number of minutes. Adding a new preset (e.g. "Every
+> 2 weeks") is a one-line change in the settings page — no backend or database
+> change needed.
+
+## The core idea: one cursor per user
+
+The system does **not** keep a record of "we sent show X to user Y." That would be
+a lot of rows to store and clean up. Instead, each subscriber has a single
+timestamp per channel:
+
+- **`lastNotifiedAt`** — the moment we last emailed this user for this channel.
+  (Empty if we've never emailed them yet.)
+
+Think of it as a bookmark. Everything queued *before* the bookmark has been handled;
+everything queued *after* it is still owed to the user.
+
+New shows and new comics are written into small "to-be-announced" queues as they're
+discovered (`new_show_queue` and `new_comic_queue`). These queue rows are **kept
+around**, not deleted the moment one email goes out — because a weekly or monthly
+subscriber may still need an item that an "immediately" subscriber already received.
+
+## How a user gets emailed
+
+A background job runs **every 15 minutes**. On each run, for each channel, it asks a
+simple question about every subscriber:
+
+**1. Is there anything new for them?**
+Look at the queue and keep only the items queued *after* their `lastNotifiedAt`
+bookmark. If there's nothing newer than their bookmark, skip them.
+
+**2. Is it time to email them again?**
+Compare `now − lastNotifiedAt` against their chosen cadence:
+
+- Immediately → 60 minutes (see "the batch window" below)
+- Weekly → 7 days
+- Monthly → 30 days
+
+If not enough time has passed, skip them for now.
+
+**Both** questions must pass. When they do, we:
+
+1. Move their bookmark forward (`lastNotifiedAt = now`) — **before** sending.
+2. Build one email containing the new items and send it.
+
+That's the whole loop. There's no scheduler picking exact send times — the job just
+wakes up every 15 minutes and asks these two questions.
+
+## The batch window (why "immediately" isn't instant)
+
+New shows are usually posted in a burst over about an hour. If we emailed on every
+15-minute tick, a user could get several emails for one batch of shows.
+
+So "immediately" really means **"at most once per hour."** New items are held for a
+60-minute window so a burst arrives in a **single** email. This 60-minute window is
+also a floor for *every* cadence — no one is ever emailed more than once per hour,
+whatever their setting.
+
+The first email a brand-new subscriber gets also waits for this window (rather than
+the full 7 or 30 days), so a new weekly subscriber still gets a starter digest
+promptly, then settles into their weekly rhythm afterward.
+
+## Keeping the queues from growing forever
+
+Because queue rows are kept (not deleted on send), they're cleaned up on a schedule
+instead:
+
+- **New shows** — a queued show is dropped once the show has **already started**.
+  We only ever email people about **upcoming** shows, so a show in the past is useless
+  to everyone. (This means: if a show was added after your bookmark but has already
+  happened by the time your weekly digest fires, you simply won't hear about it —
+  which is what you'd want.)
+- **New comics** — a comic has no "showtime" to expire, so queued comics are dropped
+  after **45 days**. That's comfortably longer than the longest cadence (monthly, 30
+  days), so a monthly subscriber never misses one.
+
+## Worked example
+
+Two users subscribe to **New Show Alerts**:
+
+- **Ava** — Immediately
+- **Ben** — Weekly
+
+Timeline:
+
+| When | What happens |
+|---|---|
+| 09:01 | SHOW-1 is discovered and queued |
+| 09:03 | SHOW-2 is discovered and queued (2 minutes later) |
+| 09:15–10:00 | Job runs, but the 60-minute batch window hasn't passed → nobody emailed yet |
+| **10:15** | Window passed. **Both** Ava and Ben get **one** email with SHOW-1 + SHOW-2. Both bookmarks move to 10:15. |
+| 10:20 | SHOW-3 is discovered and queued |
+| **11:15** | SHOW-3 is newer than both bookmarks (10:15). Ava's cadence (60 min) has elapsed → **Ava is emailed SHOW-3**, bookmark → 11:15. Ben's cadence (7 days) has **not** elapsed → Ben waits, bookmark stays 10:15. |
+| ... | SHOW-3 stays in the queue (it hasn't started yet) |
+| **7 days later** | Ben's 7 days are up. SHOW-3 is still newer than his bookmark (10:15) → **Ben is emailed SHOW-3**, bookmark advances. Ava gets nothing — her bookmark (11:15) is already past SHOW-3, so it's not "new" for her. |
+
+Two things this shows:
+
+- **The two shows 2 minutes apart become one email**, thanks to the batch window.
+- **Ava and Ben diverge** for SHOW-3: Ava gets it the same morning, Ben gets it a week
+  later, and neither gets it twice — purely from comparing each user's bookmark
+  against when items were queued.
+
+## Where this lives in the code
+
+| Piece | File |
+|---|---|
+| Cadence values, presets, batch window, interval math | `packages/core/common/notificationFrequency.ts` |
+| The "who is due and what do they get" decision | `packages/core/notificationDelivery.ts` (`selectDueRecipients`) |
+| Per-user settings + bookmark (new shows) | `packages/core/models/showNotification.ts`, `packages/core/sql/showNotification.sql.ts` |
+| Per-user settings + bookmark (new comics) | `packages/core/models/newComicNotification.ts`, `packages/core/sql/newComicNotification.sql.ts` |
+| The show queue + pruning | `packages/core/models/newShowQueue.ts` |
+| The comic queue + pruning | `packages/core/models/newComicQueue.ts` |
+| The 15-minute jobs that send the emails | `packages/functions/cron/showNotificationCron.ts`, `packages/functions/cron/newComicNotificationCron.ts` |
+| Read/write the setting | `packages/functions/settings/index.ts` |
+| The settings UI | `packages/frontend/src/pages/Profile/profileSettings.tsx` |
+
+### The two database columns that make it work
+
+On both `show_notification` and `new_comic_notification`:
+
+- **`frequencyMinutes`** (integer, default `0`) — the chosen cadence. `0` = immediately.
+- **`lastNotifiedAt`** (timestamp, nullable) — the bookmark. Empty until the first email.
+
+Added in migration `migrations/0004_email_frequency.sql`.
+
+## One assumption to be aware of
+
+The bookmark is a "high-water mark" — it assumes items are always queued in time
+order, so "everything before the bookmark is handled" holds true. In normal operation
+an item's queue time is just "now, when we discovered it," so this is always the case.
+The only thing that would break it is **back-filling** an item with an old queue time:
+a user whose bookmark already moved past that time would never see it. If back-fill
+logic is ever added, that's the edge to design around.

--- a/migrations/0004_email_frequency.sql
+++ b/migrations/0004_email_frequency.sql
@@ -1,0 +1,35 @@
+CREATE TABLE "comic_notification_queue" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"externalId" varchar(128) NOT NULL,
+	"actId" integer NOT NULL,
+	"notifiedAt" timestamp,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "comic_notification_queue_externalId_unique" UNIQUE("externalId")
+);
+--> statement-breakpoint
+CREATE TABLE "new_comic_notification" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"externalId" varchar(128) NOT NULL,
+	"userId" integer NOT NULL,
+	"enabled" boolean DEFAULT false NOT NULL,
+	"frequency" varchar(16) DEFAULT 'immediately' NOT NULL,
+	"lastNotifiedAt" timestamp,
+	"createdAt" timestamp DEFAULT now(),
+	CONSTRAINT "new_comic_notification_externalId_unique" UNIQUE("externalId")
+);
+--> statement-breakpoint
+CREATE TABLE "new_comic_queue" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"comicId" integer NOT NULL,
+	"notifiedAt" timestamp,
+	"createdAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "show_notification" ADD COLUMN "frequency" varchar(16) DEFAULT 'immediately' NOT NULL;--> statement-breakpoint
+ALTER TABLE "show_notification" ADD COLUMN "lastNotifiedAt" timestamp;--> statement-breakpoint
+ALTER TABLE "comic_notification_queue" ADD CONSTRAINT "comic_notification_queue_actId_act_id_fk" FOREIGN KEY ("actId") REFERENCES "public"."act"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "new_comic_notification" ADD CONSTRAINT "new_comic_notification_userId_user_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "new_comic_queue" ADD CONSTRAINT "new_comic_queue_comicId_comic_id_fk" FOREIGN KEY ("comicId") REFERENCES "public"."comic"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "queue_act_unique" ON "comic_notification_queue" USING btree ("actId");--> statement-breakpoint
+CREATE UNIQUE INDEX "user_new_comic_unique" ON "new_comic_notification" USING btree ("userId");--> statement-breakpoint
+CREATE UNIQUE INDEX "queue_comic_unique" ON "new_comic_queue" USING btree ("comicId");

--- a/migrations/0004_email_frequency.sql
+++ b/migrations/0004_email_frequency.sql
@@ -12,7 +12,7 @@ CREATE TABLE "new_comic_notification" (
 	"externalId" varchar(128) NOT NULL,
 	"userId" integer NOT NULL,
 	"enabled" boolean DEFAULT false NOT NULL,
-	"frequency" varchar(16) DEFAULT 'immediately' NOT NULL,
+	"frequencyMinutes" integer DEFAULT 0 NOT NULL,
 	"lastNotifiedAt" timestamp,
 	"createdAt" timestamp DEFAULT now(),
 	CONSTRAINT "new_comic_notification_externalId_unique" UNIQUE("externalId")
@@ -25,7 +25,7 @@ CREATE TABLE "new_comic_queue" (
 	"createdAt" timestamp DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
-ALTER TABLE "show_notification" ADD COLUMN "frequency" varchar(16) DEFAULT 'immediately' NOT NULL;--> statement-breakpoint
+ALTER TABLE "show_notification" ADD COLUMN "frequencyMinutes" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
 ALTER TABLE "show_notification" ADD COLUMN "lastNotifiedAt" timestamp;--> statement-breakpoint
 ALTER TABLE "comic_notification_queue" ADD CONSTRAINT "comic_notification_queue_actId_act_id_fk" FOREIGN KEY ("actId") REFERENCES "public"."act"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "new_comic_notification" ADD CONSTRAINT "new_comic_notification_userId_user_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint

--- a/migrations/meta/0004_snapshot.json
+++ b/migrations/meta/0004_snapshot.json
@@ -1,0 +1,1143 @@
+{
+  "id": "11619845-1bde-46e0-aaf1-16fad387459c",
+  "prevId": "6c41c8f6-a7c0-428c-91c4-04d30e8198ee",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.act": {
+      "name": "act",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "showId": {
+          "name": "showId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comicId": {
+          "name": "comicId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniqueComicShow": {
+          "name": "uniqueComicShow",
+          "columns": [
+            {
+              "expression": "comicId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "showId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "act_showId_show_id_fk": {
+          "name": "act_showId_show_id_fk",
+          "tableFrom": "act",
+          "tableTo": "show",
+          "columnsFrom": [
+            "showId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "act_comicId_comic_id_fk": {
+          "name": "act_comicId_comic_id_fk",
+          "tableFrom": "act",
+          "tableTo": "comic",
+          "columnsFrom": [
+            "comicId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "act_externalId_unique": {
+          "name": "act_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "externalId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comic": {
+      "name": "comic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "img": {
+          "name": "img",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nameUniqueIndex": {
+          "name": "nameUniqueIndex",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comic_externalId_unique": {
+          "name": "comic_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "externalId"
+          ]
+        },
+        "comic_name_unique": {
+          "name": "comic_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comic_notification": {
+      "name": "comic_notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comicId": {
+          "name": "comicId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_comic_unique": {
+          "name": "user_comic_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "comicId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comic_notification_userId_user_id_fk": {
+          "name": "comic_notification_userId_user_id_fk",
+          "tableFrom": "comic_notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comic_notification_comicId_comic_id_fk": {
+          "name": "comic_notification_comicId_comic_id_fk",
+          "tableFrom": "comic_notification",
+          "tableTo": "comic",
+          "columnsFrom": [
+            "comicId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comic_notification_externalId_unique": {
+          "name": "comic_notification_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "externalId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comic_notification_queue": {
+      "name": "comic_notification_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actId": {
+          "name": "actId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notifiedAt": {
+          "name": "notifiedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "queue_act_unique": {
+          "name": "queue_act_unique",
+          "columns": [
+            {
+              "expression": "actId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comic_notification_queue_actId_act_id_fk": {
+          "name": "comic_notification_queue_actId_act_id_fk",
+          "tableFrom": "comic_notification_queue",
+          "tableTo": "act",
+          "columnsFrom": [
+            "actId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comic_notification_queue_externalId_unique": {
+          "name": "comic_notification_queue_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "externalId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comic_to_user": {
+      "name": "comic_to_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comicId": {
+          "name": "comicId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isLiked": {
+          "name": "isLiked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_comic_unique1": {
+          "name": "user_comic_unique1",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "comicId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comic_to_user_userId_user_id_fk": {
+          "name": "comic_to_user_userId_user_id_fk",
+          "tableFrom": "comic_to_user",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comic_to_user_comicId_comic_id_fk": {
+          "name": "comic_to_user_comicId_comic_id_fk",
+          "tableFrom": "comic_to_user",
+          "tableTo": "comic",
+          "columnsFrom": [
+            "comicId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.new_comic_notification": {
+      "name": "new_comic_notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediately'"
+        },
+        "lastNotifiedAt": {
+          "name": "lastNotifiedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_new_comic_unique": {
+          "name": "user_new_comic_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "new_comic_notification_userId_user_id_fk": {
+          "name": "new_comic_notification_userId_user_id_fk",
+          "tableFrom": "new_comic_notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "new_comic_notification_externalId_unique": {
+          "name": "new_comic_notification_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "externalId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.new_comic_queue": {
+      "name": "new_comic_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "comicId": {
+          "name": "comicId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notifiedAt": {
+          "name": "notifiedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "queue_comic_unique": {
+          "name": "queue_comic_unique",
+          "columns": [
+            {
+              "expression": "comicId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "new_comic_queue_comicId_comic_id_fk": {
+          "name": "new_comic_queue_comicId_comic_id_fk",
+          "tableFrom": "new_comic_queue",
+          "tableTo": "comic",
+          "columnsFrom": [
+            "comicId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.new_show_queue": {
+      "name": "new_show_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "showId": {
+          "name": "showId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notifiedAt": {
+          "name": "notifiedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "queue_show_unique": {
+          "name": "queue_show_unique",
+          "columns": [
+            {
+              "expression": "showId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "new_show_queue_showId_show_id_fk": {
+          "name": "new_show_queue_showId_show_id_fk",
+          "tableFrom": "new_show_queue",
+          "tableTo": "show",
+          "columnsFrom": [
+            "showId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "new_show_queue_externalId_unique": {
+          "name": "new_show_queue_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "externalId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.room": {
+      "name": "room",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "maxReservationSize": {
+          "name": "maxReservationSize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 4
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "room_externalId_unique": {
+          "name": "room_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "externalId"
+          ]
+        },
+        "room_name_unique": {
+          "name": "room_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.show": {
+      "name": "show",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forwardUrl": {
+          "name": "forwardUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soldout": {
+          "name": "soldout",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max": {
+          "name": "max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "special": {
+          "name": "special",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roomId": {
+          "name": "roomId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover": {
+          "name": "cover",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mint": {
+          "name": "mint",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekday": {
+          "name": "weekday",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalGuests": {
+          "name": "totalGuests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "venueMin": {
+          "name": "venueMin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "venueMax": {
+          "name": "venueMax",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available": {
+          "name": "available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "show_roomId_room_id_fk": {
+          "name": "show_roomId_room_id_fk",
+          "tableFrom": "show",
+          "tableTo": "room",
+          "columnsFrom": [
+            "roomId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "show_externalId_unique": {
+          "name": "show_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "externalId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.show_notification": {
+      "name": "show_notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediately'"
+        },
+        "lastNotifiedAt": {
+          "name": "lastNotifiedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_show_unique": {
+          "name": "user_show_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "show_notification_userId_user_id_fk": {
+          "name": "show_notification_userId_user_id_fk",
+          "tableFrom": "show_notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "show_notification_externalId_unique": {
+          "name": "show_notification_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "externalId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authId": {
+          "name": "authId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "emailUniqueIndex": {
+          "name": "emailUniqueIndex",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_externalId_unique": {
+          "name": "user_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "externalId"
+          ]
+        },
+        "user_authId_unique": {
+          "name": "user_authId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "authId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/0004_snapshot.json
+++ b/migrations/meta/0004_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "11619845-1bde-46e0-aaf1-16fad387459c",
+  "id": "8a4290a0-055f-4a84-8fd2-04a0da7b5b58",
   "prevId": "6c41c8f6-a7c0-428c-91c4-04d30e8198ee",
   "version": "7",
   "dialect": "postgresql",
@@ -518,12 +518,12 @@
           "notNull": true,
           "default": false
         },
-        "frequency": {
-          "name": "frequency",
-          "type": "varchar(16)",
+        "frequencyMinutes": {
+          "name": "frequencyMinutes",
+          "type": "integer",
           "primaryKey": false,
           "notNull": true,
-          "default": "'immediately'"
+          "default": 0
         },
         "lastNotifiedAt": {
           "name": "lastNotifiedAt",
@@ -974,12 +974,12 @@
           "notNull": true,
           "default": false
         },
-        "frequency": {
-          "name": "frequency",
-          "type": "varchar(16)",
+        "frequencyMinutes": {
+          "name": "frequencyMinutes",
+          "type": "integer",
           "primaryKey": false,
           "notNull": true,
-          "default": "'immediately'"
+          "default": 0
         },
         "lastNotifiedAt": {
           "name": "lastNotifiedAt",

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1783796566427,
       "tag": "0003_dizzy_lady_ursula",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1786454903312,
+      "tag": "0004_email_frequency",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -33,7 +33,7 @@
     {
       "idx": 4,
       "version": "7",
-      "when": 1786454903312,
+      "when": 1786464999883,
       "tag": "0004_email_frequency",
       "breakpoints": true
     }

--- a/packages/core/common/notificationFrequency.ts
+++ b/packages/core/common/notificationFrequency.ts
@@ -1,0 +1,48 @@
+// Delivery cadence for the two GLOBAL subscriber emails (new shows, new
+// comics). It does NOT apply to the per-comic "a comic I follow was booked"
+// emails — those stay event-driven.
+//
+//   immediately — send as soon as there is something to announce (still held
+//                 for the short batch window so a burst of new shows/comics
+//                 rides in one email; this is the historical behaviour).
+//   weekly      — at most one digest every 7 days.
+//   monthly     — at most one digest every 30 days.
+export const NOTIFICATION_FREQUENCIES = [
+  "immediately",
+  "weekly",
+  "monthly",
+] as const;
+
+export type NotificationFrequency = (typeof NOTIFICATION_FREQUENCIES)[number];
+
+export const DEFAULT_NOTIFICATION_FREQUENCY: NotificationFrequency =
+  "immediately";
+
+export function isNotificationFrequency(
+  value: unknown
+): value is NotificationFrequency {
+  return (
+    typeof value === "string" &&
+    (NOTIFICATION_FREQUENCIES as readonly string[]).includes(value)
+  );
+}
+
+// "immediately" still batches new items for up to an hour before sending so a
+// burst of shows/comics posted together arrives in a single email.
+export const IMMEDIATE_BATCH_WINDOW_MINUTES = 60;
+
+const MINUTES = 60 * 1000;
+const DAYS = 24 * 60 * MINUTES;
+
+// Minimum time between two digests for a recipient at the given cadence.
+export function frequencyIntervalMs(frequency: NotificationFrequency): number {
+  switch (frequency) {
+    case "weekly":
+      return 7 * DAYS;
+    case "monthly":
+      return 30 * DAYS;
+    case "immediately":
+    default:
+      return IMMEDIATE_BATCH_WINDOW_MINUTES * MINUTES;
+  }
+}

--- a/packages/core/common/notificationFrequency.ts
+++ b/packages/core/common/notificationFrequency.ts
@@ -2,47 +2,60 @@
 // comics). It does NOT apply to the per-comic "a comic I follow was booked"
 // emails — those stay event-driven.
 //
-//   immediately — send as soon as there is something to announce (still held
-//                 for the short batch window so a burst of new shows/comics
-//                 rides in one email; this is the historical behaviour).
-//   weekly      — at most one digest every 7 days.
-//   monthly     — at most one digest every 30 days.
-export const NOTIFICATION_FREQUENCIES = [
-  "immediately",
-  "weekly",
-  "monthly",
+// The cadence is stored as an arbitrary INTERVAL IN MINUTES so any value is
+// possible on the backend; the UI only exposes a curated set of presets (see
+// FREQUENCY_PRESETS) so end users pick a friendly label rather than a number.
+//
+//   0 (immediately) — send as soon as there is something to announce. Still
+//                     held for the short batch window (below) so a burst of new
+//                     shows/comics rides in one email; this is the historical
+//                     behaviour.
+//   any N > 0       — at most one digest every N minutes.
+
+export const MINUTES_PER_DAY = 24 * 60;
+
+// "immediately" still batches new items for up to an hour before sending, and
+// this doubles as the GLOBAL minimum spacing between any two digests: no
+// cadence, however small, emails a user more often than once per window.
+export const IMMEDIATE_BATCH_WINDOW_MINUTES = 60;
+
+export const FREQUENCY_IMMEDIATELY = 0;
+export const FREQUENCY_WEEKLY = 7 * MINUTES_PER_DAY; // 10080
+export const FREQUENCY_MONTHLY = 30 * MINUTES_PER_DAY; // 43200
+
+export const DEFAULT_FREQUENCY_MINUTES = FREQUENCY_IMMEDIATELY;
+
+// The longest cadence the pipeline can honour is bounded by how long queue rows
+// are retained (see COMIC_QUEUE_RETENTION_DAYS in models/newComicQueue.ts):
+// a subscriber's cursor may be up to their cadence old, and the items queued
+// since then must still exist. Keep this comfortably below the retention window
+// so a max-cadence digest is never assembled from a half-pruned queue.
+export const MAX_FREQUENCY_MINUTES = 40 * MINUTES_PER_DAY; // 57600
+
+// Curated presets the UI offers. Storage/validation is not limited to these —
+// they exist purely so end users pick a label instead of typing minutes.
+export const FREQUENCY_PRESETS = [
+  { label: "Immediately", minutes: FREQUENCY_IMMEDIATELY },
+  { label: "Weekly", minutes: FREQUENCY_WEEKLY },
+  { label: "Monthly", minutes: FREQUENCY_MONTHLY },
 ] as const;
 
-export type NotificationFrequency = (typeof NOTIFICATION_FREQUENCIES)[number];
-
-export const DEFAULT_NOTIFICATION_FREQUENCY: NotificationFrequency =
-  "immediately";
-
-export function isNotificationFrequency(
-  value: unknown
-): value is NotificationFrequency {
+export function isValidFrequencyMinutes(value: unknown): value is number {
   return (
-    typeof value === "string" &&
-    (NOTIFICATION_FREQUENCIES as readonly string[]).includes(value)
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= 0 &&
+    value <= MAX_FREQUENCY_MINUTES
   );
 }
 
-// "immediately" still batches new items for up to an hour before sending so a
-// burst of shows/comics posted together arrives in a single email.
-export const IMMEDIATE_BATCH_WINDOW_MINUTES = 60;
-
-const MINUTES = 60 * 1000;
-const DAYS = 24 * 60 * MINUTES;
-
-// Minimum time between two digests for a recipient at the given cadence.
-export function frequencyIntervalMs(frequency: NotificationFrequency): number {
-  switch (frequency) {
-    case "weekly":
-      return 7 * DAYS;
-    case "monthly":
-      return 30 * DAYS;
-    case "immediately":
-    default:
-      return IMMEDIATE_BATCH_WINDOW_MINUTES * MINUTES;
-  }
+// Minimum time between two digests for a recipient at the given cadence. The
+// batch window is a floor, so an "immediately" (0) subscriber is still spaced
+// by one window and never emailed more than once per window.
+export function frequencyIntervalMs(frequencyMinutes: number): number {
+  const effectiveMinutes = Math.max(
+    frequencyMinutes,
+    IMMEDIATE_BATCH_WINDOW_MINUTES
+  );
+  return effectiveMinutes * 60 * 1000;
 }

--- a/packages/core/models/newComicNotification.ts
+++ b/packages/core/models/newComicNotification.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { db } from "@core/database";
 import {
   newComicNotification,
@@ -13,14 +13,19 @@ const SST_STAGE = Resource.App.stage;
 export async function upsertNewComicNotification(
   data: InsertNewComicNotification
 ) {
+  // Only overwrite the fields the caller actually provided so that toggling
+  // `enabled` never silently resets a user's chosen `frequency`, and vice versa.
+  const set: Partial<Pick<InsertNewComicNotification, "enabled" | "frequency">> =
+    {};
+  if (data.enabled !== undefined) set.enabled = data.enabled;
+  if (data.frequency !== undefined) set.frequency = data.frequency;
+
   return db
     .insert(newComicNotification)
     .values(data)
     .onConflictDoUpdate({
       target: newComicNotification.userId,
-      set: {
-        enabled: data.enabled ?? false,
-      },
+      set,
     });
 }
 
@@ -33,14 +38,33 @@ export async function getNewComicNotification(
     .where(eq(newComicNotification.userId, userId));
 }
 
-// Everyone (for the current stage) who opted in to hear about new comics.
+// Everyone (for the current stage) who opted in to hear about new comics, with
+// the per-user delivery cursor the cron needs to honour their chosen cadence.
 // externalId is returned so the cron can mint a per-recipient unsubscribe link.
 export async function getNewComicNotificationRecipients() {
   return db
-    .select({ email: user.email, externalId: user.externalId })
+    .select({
+      userId: user.id,
+      email: user.email,
+      externalId: user.externalId,
+      frequency: newComicNotification.frequency,
+      lastNotifiedAt: newComicNotification.lastNotifiedAt,
+    })
     .from(newComicNotification)
     .innerJoin(user, eq(user.id, newComicNotification.userId))
     .where(
       and(eq(newComicNotification.enabled, true), eq(user.stage, SST_STAGE))
     );
+}
+
+// Advance the delivery cursor for the users we just emailed (or are about to).
+export async function markNewComicNotificationsNotified(
+  userIds: SelectNewComicNotification["userId"][],
+  notifiedAt: Date
+) {
+  if (!userIds.length) return;
+  await db
+    .update(newComicNotification)
+    .set({ lastNotifiedAt: notifiedAt })
+    .where(inArray(newComicNotification.userId, userIds));
 }

--- a/packages/core/models/newComicNotification.ts
+++ b/packages/core/models/newComicNotification.ts
@@ -15,10 +15,12 @@ export async function upsertNewComicNotification(
 ) {
   // Only overwrite the fields the caller actually provided so that toggling
   // `enabled` never silently resets a user's chosen `frequency`, and vice versa.
-  const set: Partial<Pick<InsertNewComicNotification, "enabled" | "frequency">> =
-    {};
+  const set: Partial<
+    Pick<InsertNewComicNotification, "enabled" | "frequencyMinutes">
+  > = {};
   if (data.enabled !== undefined) set.enabled = data.enabled;
-  if (data.frequency !== undefined) set.frequency = data.frequency;
+  if (data.frequencyMinutes !== undefined)
+    set.frequencyMinutes = data.frequencyMinutes;
 
   return db
     .insert(newComicNotification)
@@ -47,7 +49,7 @@ export async function getNewComicNotificationRecipients() {
       userId: user.id,
       email: user.email,
       externalId: user.externalId,
-      frequency: newComicNotification.frequency,
+      frequencyMinutes: newComicNotification.frequencyMinutes,
       lastNotifiedAt: newComicNotification.lastNotifiedAt,
     })
     .from(newComicNotification)

--- a/packages/core/models/newComicQueue.ts
+++ b/packages/core/models/newComicQueue.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, getTableColumns, inArray, isNull } from "drizzle-orm";
+import { asc, eq, getTableColumns, gte, lt } from "drizzle-orm";
 import { db } from "@core/database";
 import {
   newComicQueue,
@@ -12,6 +12,11 @@ export type PendingNewComic = {
   comic: SelectComic;
 };
 
+// Comics queued more than this long ago are dropped. Must comfortably exceed
+// the longest cadence (monthly, 30 days) so a monthly subscriber never misses a
+// comic that was queued between two of their digests.
+export const COMIC_QUEUE_RETENTION_DAYS = 45;
+
 export function enqueueNewComics(comicIds: SelectComic["id"][]) {
   if (!comicIds.length) return Promise.resolve([]);
   return db
@@ -21,7 +26,16 @@ export function enqueueNewComics(comicIds: SelectComic["id"][]) {
     .returning({ id: newComicQueue.id });
 }
 
-export async function getPendingNewComics(): Promise<PendingNewComic[]> {
+// Comics still within the retention window, cadence-agnostic. Rows are retained
+// (not cleared once announced) so weekly/monthly subscribers can still receive
+// a comic that "immediately" subscribers already saw — per-user delivery is
+// gated by each subscriber's cursor, not by a global notifiedAt flag.
+export async function getPendingNewComics(
+  now: Date = new Date()
+): Promise<PendingNewComic[]> {
+  const cutoff = new Date(
+    now.getTime() - COMIC_QUEUE_RETENTION_DAYS * 24 * 60 * 60 * 1000
+  );
   return db
     .select({
       queueId: newComicQueue.id,
@@ -30,21 +44,15 @@ export async function getPendingNewComics(): Promise<PendingNewComic[]> {
     })
     .from(newComicQueue)
     .innerJoin(comic, eq(comic.id, newComicQueue.comicId))
-    .where(isNull(newComicQueue.notifiedAt))
+    .where(gte(newComicQueue.createdAt, cutoff))
     .orderBy(asc(newComicQueue.createdAt));
 }
 
-// Marks queue rows as handled and returns only the rows this caller actually
-// claimed, so overlapping cron runs never announce the same comic twice.
-export async function claimPendingNewComics(
-  queueIds: SelectNewComicQueue["id"][]
-) {
-  if (!queueIds.length) return [];
-  return db
-    .update(newComicQueue)
-    .set({ notifiedAt: new Date() })
-    .where(
-      and(inArray(newComicQueue.id, queueIds), isNull(newComicQueue.notifiedAt))
-    )
-    .returning({ id: newComicQueue.id, comicId: newComicQueue.comicId });
+// Drop comic queue rows older than the retention window to keep the table
+// bounded; nothing needs them once every cadence has had a chance to send.
+export async function pruneOldComics(now: Date = new Date()) {
+  const cutoff = new Date(
+    now.getTime() - COMIC_QUEUE_RETENTION_DAYS * 24 * 60 * 60 * 1000
+  );
+  await db.delete(newComicQueue).where(lt(newComicQueue.createdAt, cutoff));
 }

--- a/packages/core/models/newShowQueue.ts
+++ b/packages/core/models/newShowQueue.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, getTableColumns, inArray, isNull } from "drizzle-orm";
+import { asc, eq, getTableColumns, gt, inArray, lte } from "drizzle-orm";
 import { db } from "@core/database";
 import {
   newShowQueue,
@@ -23,7 +23,15 @@ export function enqueueNewShows(showIds: SelectShow["id"][]) {
     .returning({ id: newShowQueue.id });
 }
 
-export async function getPendingNewShows(): Promise<PendingNewShow[]> {
+// Upcoming queued shows, newest-cadence-agnostic. Rows are retained (not
+// cleared once announced) so weekly/monthly subscribers can still receive a
+// show that "immediately" subscribers already saw — per-user delivery is gated
+// by each subscriber's cursor, not by a global notifiedAt flag. Only shows that
+// have not started yet are returned; past shows are pruned by prunePastShows.
+export async function getPendingNewShows(
+  now: Date = new Date()
+): Promise<PendingNewShow[]> {
+  const nowInSeconds = Math.floor(now.getTime() / 1000);
   return db
     .select({
       queueId: newShowQueue.id,
@@ -34,21 +42,17 @@ export async function getPendingNewShows(): Promise<PendingNewShow[]> {
     .from(newShowQueue)
     .innerJoin(show, eq(show.id, newShowQueue.showId))
     .leftJoin(room, eq(room.id, show.roomId))
-    .where(isNull(newShowQueue.notifiedAt))
+    .where(gt(show.timestamp, nowInSeconds))
     .orderBy(asc(show.timestamp));
 }
 
-// Marks queue rows as handled and returns only the rows this caller actually
-// claimed, so overlapping cron runs never announce the same show twice.
-export async function claimPendingNewShows(
-  queueIds: SelectNewShowQueue["id"][]
-) {
-  if (!queueIds.length) return [];
-  return db
-    .update(newShowQueue)
-    .set({ notifiedAt: new Date() })
-    .where(
-      and(inArray(newShowQueue.id, queueIds), isNull(newShowQueue.notifiedAt))
-    )
-    .returning({ id: newShowQueue.id, showId: newShowQueue.showId });
+// A show that has already started is useless to every cadence, so drop its
+// queue row to keep the table bounded.
+export async function prunePastShows(now: Date = new Date()) {
+  const nowInSeconds = Math.floor(now.getTime() / 1000);
+  const staleShowIds = db
+    .select({ id: show.id })
+    .from(show)
+    .where(lte(show.timestamp, nowInSeconds));
+  await db.delete(newShowQueue).where(inArray(newShowQueue.showId, staleShowIds));
 }

--- a/packages/core/models/showNotification.ts
+++ b/packages/core/models/showNotification.ts
@@ -13,9 +13,12 @@ const SST_STAGE = Resource.App.stage;
 export async function upsertShowNotification(data: InsertShowNotification) {
   // Only overwrite the fields the caller actually provided so that toggling
   // `enabled` never silently resets a user's chosen `frequency`, and vice versa.
-  const set: Partial<Pick<InsertShowNotification, "enabled" | "frequency">> = {};
+  const set: Partial<
+    Pick<InsertShowNotification, "enabled" | "frequencyMinutes">
+  > = {};
   if (data.enabled !== undefined) set.enabled = data.enabled;
-  if (data.frequency !== undefined) set.frequency = data.frequency;
+  if (data.frequencyMinutes !== undefined)
+    set.frequencyMinutes = data.frequencyMinutes;
 
   return db
     .insert(showNotification)
@@ -44,7 +47,7 @@ export async function getShowNotificationRecipients() {
       userId: user.id,
       email: user.email,
       externalId: user.externalId,
-      frequency: showNotification.frequency,
+      frequencyMinutes: showNotification.frequencyMinutes,
       lastNotifiedAt: showNotification.lastNotifiedAt,
     })
     .from(showNotification)

--- a/packages/core/models/showNotification.ts
+++ b/packages/core/models/showNotification.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { db } from "@core/database";
 import {
   showNotification,
@@ -11,14 +11,18 @@ import { Resource } from "sst";
 const SST_STAGE = Resource.App.stage;
 
 export async function upsertShowNotification(data: InsertShowNotification) {
+  // Only overwrite the fields the caller actually provided so that toggling
+  // `enabled` never silently resets a user's chosen `frequency`, and vice versa.
+  const set: Partial<Pick<InsertShowNotification, "enabled" | "frequency">> = {};
+  if (data.enabled !== undefined) set.enabled = data.enabled;
+  if (data.frequency !== undefined) set.frequency = data.frequency;
+
   return db
     .insert(showNotification)
     .values(data)
     .onConflictDoUpdate({
       target: showNotification.userId,
-      set: {
-        enabled: data.enabled ?? false,
-      },
+      set,
     });
 }
 
@@ -31,14 +35,33 @@ export async function getShowNotification(
     .where(eq(showNotification.userId, userId));
 }
 
-// Everyone (for the current stage) who opted in to hear about new shows.
+// Everyone (for the current stage) who opted in to hear about new shows, with
+// the per-user delivery cursor the cron needs to honour their chosen cadence.
 // externalId is returned so the cron can mint a per-recipient unsubscribe link.
 export async function getShowNotificationRecipients() {
   return db
-    .select({ email: user.email, externalId: user.externalId })
+    .select({
+      userId: user.id,
+      email: user.email,
+      externalId: user.externalId,
+      frequency: showNotification.frequency,
+      lastNotifiedAt: showNotification.lastNotifiedAt,
+    })
     .from(showNotification)
     .innerJoin(user, eq(user.id, showNotification.userId))
     .where(
       and(eq(showNotification.enabled, true), eq(user.stage, SST_STAGE))
     );
+}
+
+// Advance the delivery cursor for the users we just emailed (or are about to).
+export async function markShowNotificationsNotified(
+  userIds: SelectShowNotification["userId"][],
+  notifiedAt: Date
+) {
+  if (!userIds.length) return;
+  await db
+    .update(showNotification)
+    .set({ lastNotifiedAt: notifiedAt })
+    .where(inArray(showNotification.userId, userIds));
 }

--- a/packages/core/notificationDelivery.ts
+++ b/packages/core/notificationDelivery.ts
@@ -3,7 +3,6 @@ import { differenceInMilliseconds } from "date-fns";
 import {
   IMMEDIATE_BATCH_WINDOW_MINUTES,
   frequencyIntervalMs,
-  isNotificationFrequency,
 } from "./common/notificationFrequency";
 
 // A subscriber to one of the global digests (new shows / new comics), carrying
@@ -12,7 +11,7 @@ export type DigestRecipient = {
   userId: number;
   email: string;
   externalId: string;
-  frequency: string;
+  frequencyMinutes: number;
   lastNotifiedAt: Date | null;
 };
 
@@ -36,9 +35,9 @@ export function selectDueRecipients<
   const due: Array<{ recipient: R; items: I[] }> = [];
 
   for (const recipient of recipients) {
-    const frequency = isNotificationFrequency(recipient.frequency)
-      ? recipient.frequency
-      : "immediately";
+    const frequencyMinutes = Number.isFinite(recipient.frequencyMinutes)
+      ? Math.max(0, recipient.frequencyMinutes)
+      : 0;
     const cursor = recipient.lastNotifiedAt;
 
     // Everything this recipient has not been told about yet.
@@ -47,7 +46,10 @@ export function selectDueRecipients<
 
     if (cursor) {
       // Already had a digest — enforce the cadence between digests.
-      if (differenceInMilliseconds(now, cursor) < frequencyIntervalMs(frequency)) {
+      if (
+        differenceInMilliseconds(now, cursor) <
+        frequencyIntervalMs(frequencyMinutes)
+      ) {
         continue;
       }
     } else {

--- a/packages/core/notificationDelivery.ts
+++ b/packages/core/notificationDelivery.ts
@@ -1,0 +1,70 @@
+import { differenceInMilliseconds } from "date-fns";
+
+import {
+  IMMEDIATE_BATCH_WINDOW_MINUTES,
+  frequencyIntervalMs,
+  isNotificationFrequency,
+} from "./common/notificationFrequency";
+
+// A subscriber to one of the global digests (new shows / new comics), carrying
+// the per-user delivery cursor needed to honour their chosen cadence.
+export type DigestRecipient = {
+  userId: number;
+  email: string;
+  externalId: string;
+  frequency: string;
+  lastNotifiedAt: Date | null;
+};
+
+// Anything queued for announcement; only its enqueue time matters here.
+export type QueuedItem = { queuedAt: Date };
+
+const IMMEDIATE_BATCH_WINDOW_MS = IMMEDIATE_BATCH_WINDOW_MINUTES * 60 * 1000;
+
+// Given every subscriber and every still-pending item, decide who gets an email
+// on this tick and which items each one should receive.
+//
+// Per-user cursor model: a recipient is owed every item queued AFTER their
+// `lastNotifiedAt`, but never more often than their cadence allows. This
+// replaces the old global "claim the whole queue once" outbox so that a weekly
+// or monthly subscriber can still be served items an "immediately" subscriber
+// already saw.
+export function selectDueRecipients<
+  R extends DigestRecipient,
+  I extends QueuedItem
+>(recipients: R[], pending: I[], now: Date): Array<{ recipient: R; items: I[] }> {
+  const due: Array<{ recipient: R; items: I[] }> = [];
+
+  for (const recipient of recipients) {
+    const frequency = isNotificationFrequency(recipient.frequency)
+      ? recipient.frequency
+      : "immediately";
+    const cursor = recipient.lastNotifiedAt;
+
+    // Everything this recipient has not been told about yet.
+    const items = pending.filter((item) => !cursor || item.queuedAt > cursor);
+    if (!items.length) continue;
+
+    if (cursor) {
+      // Already had a digest — enforce the cadence between digests.
+      if (differenceInMilliseconds(now, cursor) < frequencyIntervalMs(frequency)) {
+        continue;
+      }
+    } else {
+      // Never notified. Hold the very first digest for the short batch window
+      // so a burst of items posted together arrives in one email; the cadence
+      // then applies from this first send onward, regardless of frequency.
+      const oldest = items.reduce(
+        (min, item) => (item.queuedAt < min ? item.queuedAt : min),
+        items[0].queuedAt
+      );
+      if (differenceInMilliseconds(now, oldest) < IMMEDIATE_BATCH_WINDOW_MS) {
+        continue;
+      }
+    }
+
+    due.push({ recipient, items });
+  }
+
+  return due;
+}

--- a/packages/core/sql/newComicNotification.sql.ts
+++ b/packages/core/sql/newComicNotification.sql.ts
@@ -9,7 +9,7 @@ import {
 } from "drizzle-orm/pg-core";
 
 import { NEW_COMIC_NOTIFICATION_PREFIX } from "../common/constants";
-import { DEFAULT_NOTIFICATION_FREQUENCY } from "../common/notificationFrequency";
+import { DEFAULT_FREQUENCY_MINUTES } from "../common/notificationFrequency";
 import { createExternalId } from "../common/createExternalId";
 import { relations } from "drizzle-orm";
 import { user } from "./user.sql";
@@ -30,11 +30,12 @@ export const newComicNotification = pgTable(
       .references(() => user.id, { onDelete: "cascade" })
       .notNull(),
     enabled: boolean("enabled").notNull().default(false),
-    // How often this user wants the global "new comics" email. See
-    // common/notificationFrequency.ts. Only meaningful when enabled.
-    frequency: varchar("frequency", { length: 16 })
+    // How often this user wants the global "new comics" email, as an arbitrary
+    // interval in minutes (0 = immediately). See common/notificationFrequency.ts.
+    // Only meaningful when enabled.
+    frequencyMinutes: integer("frequencyMinutes")
       .notNull()
-      .default(DEFAULT_NOTIFICATION_FREQUENCY),
+      .default(DEFAULT_FREQUENCY_MINUTES),
     // When we last sent this user a new-comics digest (per-user delivery
     // cursor). NULL = never notified yet.
     lastNotifiedAt: timestamp("lastNotifiedAt"),

--- a/packages/core/sql/newComicNotification.sql.ts
+++ b/packages/core/sql/newComicNotification.sql.ts
@@ -9,6 +9,7 @@ import {
 } from "drizzle-orm/pg-core";
 
 import { NEW_COMIC_NOTIFICATION_PREFIX } from "../common/constants";
+import { DEFAULT_NOTIFICATION_FREQUENCY } from "../common/notificationFrequency";
 import { createExternalId } from "../common/createExternalId";
 import { relations } from "drizzle-orm";
 import { user } from "./user.sql";
@@ -29,6 +30,14 @@ export const newComicNotification = pgTable(
       .references(() => user.id, { onDelete: "cascade" })
       .notNull(),
     enabled: boolean("enabled").notNull().default(false),
+    // How often this user wants the global "new comics" email. See
+    // common/notificationFrequency.ts. Only meaningful when enabled.
+    frequency: varchar("frequency", { length: 16 })
+      .notNull()
+      .default(DEFAULT_NOTIFICATION_FREQUENCY),
+    // When we last sent this user a new-comics digest (per-user delivery
+    // cursor). NULL = never notified yet.
+    lastNotifiedAt: timestamp("lastNotifiedAt"),
     createdAt: timestamp("createdAt").defaultNow(),
   },
   (table) => ({

--- a/packages/core/sql/showNotification.sql.ts
+++ b/packages/core/sql/showNotification.sql.ts
@@ -9,7 +9,7 @@ import {
 } from "drizzle-orm/pg-core";
 
 import { SHOW_NOTIFICATION_PREFIX } from "../common/constants";
-import { DEFAULT_NOTIFICATION_FREQUENCY } from "../common/notificationFrequency";
+import { DEFAULT_FREQUENCY_MINUTES } from "../common/notificationFrequency";
 import { createExternalId } from "../common/createExternalId";
 import { relations } from "drizzle-orm";
 import { user } from "./user.sql";
@@ -28,11 +28,12 @@ export const showNotification = pgTable(
       .references(() => user.id, { onDelete: "cascade" })
       .notNull(),
     enabled: boolean("enabled").notNull().default(false),
-    // How often this user wants the global "new shows" email. See
-    // common/notificationFrequency.ts. Only meaningful when enabled.
-    frequency: varchar("frequency", { length: 16 })
+    // How often this user wants the global "new shows" email, as an arbitrary
+    // interval in minutes (0 = immediately). See common/notificationFrequency.ts.
+    // Only meaningful when enabled.
+    frequencyMinutes: integer("frequencyMinutes")
       .notNull()
-      .default(DEFAULT_NOTIFICATION_FREQUENCY),
+      .default(DEFAULT_FREQUENCY_MINUTES),
     // When we last sent this user a new-shows digest (per-user delivery
     // cursor). NULL = never notified yet.
     lastNotifiedAt: timestamp("lastNotifiedAt"),

--- a/packages/core/sql/showNotification.sql.ts
+++ b/packages/core/sql/showNotification.sql.ts
@@ -9,6 +9,7 @@ import {
 } from "drizzle-orm/pg-core";
 
 import { SHOW_NOTIFICATION_PREFIX } from "../common/constants";
+import { DEFAULT_NOTIFICATION_FREQUENCY } from "../common/notificationFrequency";
 import { createExternalId } from "../common/createExternalId";
 import { relations } from "drizzle-orm";
 import { user } from "./user.sql";
@@ -27,6 +28,14 @@ export const showNotification = pgTable(
       .references(() => user.id, { onDelete: "cascade" })
       .notNull(),
     enabled: boolean("enabled").notNull().default(false),
+    // How often this user wants the global "new shows" email. See
+    // common/notificationFrequency.ts. Only meaningful when enabled.
+    frequency: varchar("frequency", { length: 16 })
+      .notNull()
+      .default(DEFAULT_NOTIFICATION_FREQUENCY),
+    // When we last sent this user a new-shows digest (per-user delivery
+    // cursor). NULL = never notified yet.
+    lastNotifiedAt: timestamp("lastNotifiedAt"),
     createdAt: timestamp("createdAt").defaultNow(),
   },
   (table) => ({

--- a/packages/frontend/src/components/ui/SegmentedToggle.tsx
+++ b/packages/frontend/src/components/ui/SegmentedToggle.tsx
@@ -1,18 +1,18 @@
 import clsx from "clsx";
 
-export interface SegmentedToggleOption<T extends string = string> {
+export interface SegmentedToggleOption<T extends string | number = string> {
   label: string;
   value: T;
 }
 
-export interface SegmentedToggleProps<T extends string = string> {
+export interface SegmentedToggleProps<T extends string | number = string> {
   options: SegmentedToggleOption<T>[];
   value: T;
   onChange: (value: T) => void;
   className?: string;
 }
 
-export function SegmentedToggle<T extends string = string>({
+export function SegmentedToggle<T extends string | number = string>({
   options,
   value,
   onChange,

--- a/packages/frontend/src/pages/Profile/profileSettings.tsx
+++ b/packages/frontend/src/pages/Profile/profileSettings.tsx
@@ -1,9 +1,5 @@
 import { Card, CardBody, CardHeader } from "@/components/Card";
-import {
-  ComicNotification,
-  NotificationFrequency,
-  Settings,
-} from "@/types";
+import { ComicNotification, Settings } from "@/types";
 import { fetchSettings, updateSettings } from "@/utils/api";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useState } from "preact/hooks";
@@ -18,11 +14,16 @@ import { Badge } from "@/components/ui/Badge";
 import { SegmentedToggle } from "@/components/ui/SegmentedToggle";
 import { BellAlertIcon, BellSlashIcon } from "@heroicons/react/20/solid";
 
-const FREQUENCY_OPTIONS: { label: string; value: NotificationFrequency }[] = [
-  { label: "Immediately", value: "immediately" },
-  { label: "Weekly", value: "weekly" },
-  { label: "Monthly", value: "monthly" },
+// The cadence is stored as an arbitrary interval in minutes (0 = immediately);
+// the UI only exposes these curated presets so users pick a friendly label.
+// Add a row here to offer another preset — no backend change needed.
+const MINUTES_PER_DAY = 24 * 60;
+const FREQUENCY_OPTIONS: { label: string; value: number }[] = [
+  { label: "Immediately", value: 0 },
+  { label: "Weekly", value: 7 * MINUTES_PER_DAY },
+  { label: "Monthly", value: 30 * MINUTES_PER_DAY },
 ];
+const DEFAULT_FREQUENCY_MINUTES = 0;
 
 export function ProfileSettings() {
   const { data, isLoading } = useQuery<Settings>({
@@ -64,17 +65,27 @@ function FrequencyField({
   onChange,
 }: {
   label: string;
-  value: NotificationFrequency;
-  onChange: (value: NotificationFrequency) => void;
+  value: number;
+  onChange: (value: number) => void;
 }) {
+  // Snap an arbitrary stored interval to the nearest preset so a value set
+  // outside the UI still highlights a sensible option instead of nothing.
+  const selected = FREQUENCY_OPTIONS.some((option) => option.value === value)
+    ? value
+    : FREQUENCY_OPTIONS.reduce((closest, option) =>
+        Math.abs(option.value - value) < Math.abs(closest.value - value)
+          ? option
+          : closest
+      ).value;
+
   return (
     <div className="flex flex-col gap-2 pl-8">
       <span className="font-mono text-[11px] uppercase tracking-cap text-faint">
         {label}
       </span>
-      <SegmentedToggle<NotificationFrequency>
+      <SegmentedToggle<number>
         options={FREQUENCY_OPTIONS}
-        value={value}
+        value={selected}
         onChange={onChange}
       />
     </div>
@@ -89,24 +100,28 @@ function GlobalNotifications({ settings }: { settings: Settings }) {
   const [showEnabled, setShowEnabled] = useState(
     settings.showNotification.enabled ?? false
   );
-  const [showFrequency, setShowFrequency] = useState<NotificationFrequency>(
-    settings.showNotification.frequency ?? "immediately"
+  const [showFrequency, setShowFrequency] = useState<number>(
+    settings.showNotification.frequencyMinutes ?? DEFAULT_FREQUENCY_MINUTES
   );
   const [comicEnabled, setComicEnabled] = useState(
     settings.newComicNotification?.enabled ?? false
   );
-  const [comicFrequency, setComicFrequency] = useState<NotificationFrequency>(
-    settings.newComicNotification?.frequency ?? "immediately"
+  const [comicFrequency, setComicFrequency] = useState<number>(
+    settings.newComicNotification?.frequencyMinutes ??
+      DEFAULT_FREQUENCY_MINUTES
   );
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
     mutateSettings({
-      showNotification: { enabled: showEnabled, frequency: showFrequency },
+      showNotification: {
+        enabled: showEnabled,
+        frequencyMinutes: showFrequency,
+      },
       newComicNotification: {
         enabled: comicEnabled,
-        frequency: comicFrequency,
+        frequencyMinutes: comicFrequency,
       },
     });
   };

--- a/packages/frontend/src/pages/Profile/profileSettings.tsx
+++ b/packages/frontend/src/pages/Profile/profileSettings.tsx
@@ -1,7 +1,12 @@
 import { Card, CardBody, CardHeader } from "@/components/Card";
-import { ComicNotification, Settings } from "@/types";
+import {
+  ComicNotification,
+  NotificationFrequency,
+  Settings,
+} from "@/types";
 import { fetchSettings, updateSettings } from "@/utils/api";
 import { useMutation, useQuery } from "@tanstack/react-query";
+import { useState } from "preact/hooks";
 
 import { Button } from "@/components/Button";
 import { Checkbox } from "@/components/Checkbox";
@@ -10,7 +15,14 @@ import { PageLoader } from "@/components/PageLoader";
 
 import { Avatar } from "@/components/ui/Avatar";
 import { Badge } from "@/components/ui/Badge";
+import { SegmentedToggle } from "@/components/ui/SegmentedToggle";
 import { BellAlertIcon, BellSlashIcon } from "@heroicons/react/20/solid";
+
+const FREQUENCY_OPTIONS: { label: string; value: NotificationFrequency }[] = [
+  { label: "Immediately", value: "immediately" },
+  { label: "Weekly", value: "weekly" },
+  { label: "Monthly", value: "monthly" },
+];
 
 export function ProfileSettings() {
   const { data, isLoading } = useQuery<Settings>({
@@ -18,60 +30,13 @@ export function ProfileSettings() {
     queryFn: fetchSettings,
   });
 
-  const { mutate: mutateSettings, isPending } = useMutation({
-    mutationFn: updateSettings,
-  });
-
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    const formData = new FormData(e.currentTarget);
-    const showNotification = formData.get("showNotification") === "on";
-    const newComicNotification =
-      formData.get("newComicNotification") === "on";
-
-    mutateSettings({
-      showNotification: { enabled: showNotification },
-      newComicNotification: { enabled: newComicNotification },
-    });
-  };
-
-  if (isLoading) {
+  if (isLoading || !data) {
     return <PageLoader />;
   }
 
   return (
     <div className="flex flex-col gap-[22px]">
-      <Card>
-        <CardHeader>
-          <h3 className="font-display text-d-sm tracking-cap text-text">
-            Global Notifications
-          </h3>
-          <p className="mt-1 font-mono text-[11px] text-faint">
-            System-wide setting
-          </p>
-        </CardHeader>
-        <CardBody>
-          <form className="flex flex-col gap-5" onSubmit={handleSubmit}>
-            <Checkbox
-              label="showNotification"
-              displayLabel="New Show Alerts"
-              description="Get a heads-up whenever any new show is added — independent of comic notifications."
-              defaultChecked={data?.showNotification.enabled ?? false}
-            />
-            <Checkbox
-              label="newComicNotification"
-              displayLabel="New Comic Alerts"
-              description="Get an email when a comic new to the Comedy Cellar joins the lineup for the first time."
-              defaultChecked={data?.newComicNotification?.enabled ?? false}
-            />
-            <div className="flex justify-end">
-              <Button type="submit" variant="solid" disabled={isPending}>
-                {isPending ? "Saving..." : "Save"}
-              </Button>
-            </div>
-          </form>
-        </CardBody>
-      </Card>
+      <GlobalNotifications settings={data} />
 
       <Card>
         <CardHeader>
@@ -88,6 +53,112 @@ export function ProfileSettings() {
         </CardBody>
       </Card>
     </div>
+  );
+}
+
+// A cadence picker is only meaningful for an alert that is turned on, so it is
+// shown right under its toggle and hidden when the alert is off.
+function FrequencyField({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: NotificationFrequency;
+  onChange: (value: NotificationFrequency) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-2 pl-8">
+      <span className="font-mono text-[11px] uppercase tracking-cap text-faint">
+        {label}
+      </span>
+      <SegmentedToggle<NotificationFrequency>
+        options={FREQUENCY_OPTIONS}
+        value={value}
+        onChange={onChange}
+      />
+    </div>
+  );
+}
+
+function GlobalNotifications({ settings }: { settings: Settings }) {
+  const { mutate: mutateSettings, isPending } = useMutation({
+    mutationFn: updateSettings,
+  });
+
+  const [showEnabled, setShowEnabled] = useState(
+    settings.showNotification.enabled ?? false
+  );
+  const [showFrequency, setShowFrequency] = useState<NotificationFrequency>(
+    settings.showNotification.frequency ?? "immediately"
+  );
+  const [comicEnabled, setComicEnabled] = useState(
+    settings.newComicNotification?.enabled ?? false
+  );
+  const [comicFrequency, setComicFrequency] = useState<NotificationFrequency>(
+    settings.newComicNotification?.frequency ?? "immediately"
+  );
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    mutateSettings({
+      showNotification: { enabled: showEnabled, frequency: showFrequency },
+      newComicNotification: {
+        enabled: comicEnabled,
+        frequency: comicFrequency,
+      },
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <h3 className="font-display text-d-sm tracking-cap text-text">
+          Global Notifications
+        </h3>
+        <p className="mt-1 font-mono text-[11px] text-faint">
+          System-wide setting
+        </p>
+      </CardHeader>
+      <CardBody>
+        <form className="flex flex-col gap-5" onSubmit={handleSubmit}>
+          <Checkbox
+            label="showNotification"
+            displayLabel="New Show Alerts"
+            description="Get a heads-up whenever any new show is added — independent of comic notifications."
+            checked={showEnabled}
+            onChange={setShowEnabled}
+          />
+          {showEnabled && (
+            <FrequencyField
+              label="How often"
+              value={showFrequency}
+              onChange={setShowFrequency}
+            />
+          )}
+          <Checkbox
+            label="newComicNotification"
+            displayLabel="New Comic Alerts"
+            description="Get an email when a comic new to the Comedy Cellar joins the lineup for the first time."
+            checked={comicEnabled}
+            onChange={setComicEnabled}
+          />
+          {comicEnabled && (
+            <FrequencyField
+              label="How often"
+              value={comicFrequency}
+              onChange={setComicFrequency}
+            />
+          )}
+          <div className="flex justify-end">
+            <Button type="submit" variant="solid" disabled={isPending}>
+              {isPending ? "Saving..." : "Save"}
+            </Button>
+          </div>
+        </form>
+      </CardBody>
+    </Card>
   );
 }
 

--- a/packages/frontend/src/pages/Profile/profileTabs.tsx
+++ b/packages/frontend/src/pages/Profile/profileTabs.tsx
@@ -26,7 +26,7 @@ export function ProfileTabs({ children }: { children: React.ReactNode }) {
 
   return (
     <div className="flex flex-col gap-8">
-      <SegmentedToggle
+      <SegmentedToggle<string>
         options={tabNames.map((tabName) => ({
           label: tabName,
           value: tabName,

--- a/packages/frontend/src/types.ts
+++ b/packages/frontend/src/types.ts
@@ -83,13 +83,17 @@ export type Room = {
   createdAt: string;
 };
 
+export type NotificationFrequency = "immediately" | "weekly" | "monthly";
+
 export type Settings = {
   comicNotifications: ComicNotification[];
   showNotification: {
     enabled?: boolean;
+    frequency?: NotificationFrequency;
   };
   newComicNotification: {
     enabled?: boolean;
+    frequency?: NotificationFrequency;
   };
 };
 

--- a/packages/frontend/src/types.ts
+++ b/packages/frontend/src/types.ts
@@ -83,17 +83,17 @@ export type Room = {
   createdAt: string;
 };
 
-export type NotificationFrequency = "immediately" | "weekly" | "monthly";
-
+// Cadence for the global emails, stored as an arbitrary interval in minutes
+// (0 = immediately). The UI only surfaces a curated set of presets.
 export type Settings = {
   comicNotifications: ComicNotification[];
   showNotification: {
     enabled?: boolean;
-    frequency?: NotificationFrequency;
+    frequencyMinutes?: number;
   };
   newComicNotification: {
     enabled?: boolean;
-    frequency?: NotificationFrequency;
+    frequencyMinutes?: number;
   };
 };
 

--- a/packages/frontend/src/utils/api.ts
+++ b/packages/frontend/src/utils/api.ts
@@ -1,4 +1,4 @@
-import { Comic, ListApiRes, ShowDb } from "../types";
+import { Comic, ListApiRes, NotificationFrequency, ShowDb } from "../types";
 
 import { getClerk } from "./clerk";
 import qs from "qs";
@@ -173,9 +173,11 @@ type SettingPostBody = {
   }[];
   showNotification?: {
     enabled: boolean;
+    frequency?: NotificationFrequency;
   };
   newComicNotification?: {
     enabled: boolean;
+    frequency?: NotificationFrequency;
   };
 };
 export const updateSettings = async ({

--- a/packages/frontend/src/utils/api.ts
+++ b/packages/frontend/src/utils/api.ts
@@ -1,4 +1,4 @@
-import { Comic, ListApiRes, NotificationFrequency, ShowDb } from "../types";
+import { Comic, ListApiRes, ShowDb } from "../types";
 
 import { getClerk } from "./clerk";
 import qs from "qs";
@@ -173,11 +173,11 @@ type SettingPostBody = {
   }[];
   showNotification?: {
     enabled: boolean;
-    frequency?: NotificationFrequency;
+    frequencyMinutes?: number;
   };
   newComicNotification?: {
     enabled: boolean;
-    frequency?: NotificationFrequency;
+    frequencyMinutes?: number;
   };
 };
 export const updateSettings = async ({

--- a/packages/functions/cron/newComicNotificationCron.ts
+++ b/packages/functions/cron/newComicNotificationCron.ts
@@ -1,10 +1,12 @@
-import { differenceInMinutes } from "date-fns";
-
 import {
-  claimPendingNewComics,
   getPendingNewComics,
+  pruneOldComics,
 } from "@core/models/newComicQueue";
-import { getNewComicNotificationRecipients } from "@core/models/newComicNotification";
+import {
+  getNewComicNotificationRecipients,
+  markNewComicNotificationsNotified,
+} from "@core/models/newComicNotification";
+import { selectDueRecipients } from "@core/notificationDelivery";
 import { renderNewComicsEmail } from "@core/emails/newComicsEmail";
 import { sendEmail, sendHtmlEmail } from "@core/email";
 import {
@@ -16,10 +18,6 @@ import { unsubscribeUrl } from "@core/emails/shared/constants";
 const IS_ACTIVE = process.env.IS_ACTIVE === "1";
 const IS_CRON = process.env.IS_CRON === "1";
 
-// New comics are discovered as lineups are scraped over time, so hold the batch
-// until the first queued comic is this old. Anything that trickles in while we
-// wait rides along in the same email instead of spamming subscribers.
-const BATCH_WINDOW_MINUTES = 60;
 const SEND_CHUNK_SIZE = 25;
 
 export async function handler() {
@@ -27,76 +25,61 @@ export async function handler() {
     return;
   }
 
-  const pending = await getPendingNewComics();
+  const now = new Date();
+
+  // Retained outbox of recently discovered comics; each subscriber is served
+  // the ones queued since their own last digest, no more often than their
+  // cadence.
+  const pending = await getPendingNewComics(now);
 
   if (!pending.length) {
-    return {};
-  }
-
-  const now = new Date();
-  const oldestQueuedAt = pending.reduce(
-    (oldest, item) => (item.queuedAt < oldest ? item.queuedAt : oldest),
-    pending[0].queuedAt
-  );
-  const batchAgeMinutes = differenceInMinutes(now, oldestQueuedAt);
-
-  if (batchAgeMinutes < BATCH_WINDOW_MINUTES) {
-    console.log(
-      `Holding batch: ${pending.length} comic(s) queued, oldest queued ${batchAgeMinutes}m ago (window is ${BATCH_WINDOW_MINUTES}m)`
-    );
-    return {};
-  }
-
-  // Claim before sending so an overlapping run can't announce the same comics
-  const claimed = await claimPendingNewComics(
-    pending.map((item) => item.queueId)
-  );
-
-  if (!claimed.length) {
-    console.log("Batch already claimed by another run");
-    return {};
-  }
-
-  const claimedIds = new Set(claimed.map((row) => row.id));
-  const batch = pending.filter((item) => claimedIds.has(item.queueId));
-
-  if (!batch.length) {
-    console.log("No comics left in the claimed batch");
+    await pruneOldComics(now);
     return {};
   }
 
   const recipients = await getNewComicNotificationRecipients();
 
-  if (!recipients.length) {
-    console.log(`No subscribers; skipping ${batch.length} queued comic(s)`);
+  const due = selectDueRecipients(recipients, pending, now);
+
+  if (!due.length) {
+    await pruneOldComics(now);
     return {};
   }
 
-  const comics = batch.map(({ comic }) => ({
-    name: comic.name,
-    img: comic.img,
-    website: comic.website,
-    description: comic.description,
-  }));
+  // Advance every due recipient's cursor BEFORE sending so an overlapping cron
+  // run can't announce the same batch twice (mirrors the old claim-before-send
+  // guarantee). A send failure below just means that recipient misses this
+  // batch, exactly as the previous outbox behaved.
+  await markNewComicNotificationsNotified(
+    due.map(({ recipient }) => recipient.userId),
+    now
+  );
 
-  // The unsubscribe link is personalized per recipient, so render the email
-  // once per recipient with their own opaque token in the footer + one-click
-  // header.
   const failures: string[] = [];
 
-  for (let i = 0; i < recipients.length; i += SEND_CHUNK_SIZE) {
-    const chunk = recipients.slice(i, i + SEND_CHUNK_SIZE);
+  for (let i = 0; i < due.length; i += SEND_CHUNK_SIZE) {
+    const chunk = due.slice(i, i + SEND_CHUNK_SIZE);
     const results = await Promise.allSettled(
-      chunk.map(async ({ email, externalId }) => {
+      chunk.map(async ({ recipient, items }) => {
+        const comics = items.map(({ comic }) => ({
+          name: comic.name,
+          img: comic.img,
+          website: comic.website,
+          description: comic.description,
+        }));
+
         const unsubUrl = unsubscribeUrl(
-          createUnsubscribeToken(externalId, UnsubscribeChannel.NEW_COMICS)
+          createUnsubscribeToken(
+            recipient.externalId,
+            UnsubscribeChannel.NEW_COMICS
+          )
         );
         const { subject, html, text } = await renderNewComicsEmail({
           comics,
           unsubscribeUrl: unsubUrl,
         });
         return sendHtmlEmail({
-          to: email,
+          to: recipient.email,
           subject,
           html,
           text,
@@ -107,22 +90,24 @@ export async function handler() {
 
     results.forEach((result, index) => {
       if (result.status === "rejected") {
-        failures.push(`${chunk[index].email}: ${result.reason}`);
+        failures.push(`${chunk[index].recipient.email}: ${result.reason}`);
       }
     });
   }
 
   console.log(
-    `Announced ${batch.length} comic(s) to ${
-      recipients.length - failures.length
-    }/${recipients.length} subscriber(s)`
+    `Announced new comics to ${due.length - failures.length}/${
+      due.length
+    } due subscriber(s)`
   );
+
+  await pruneOldComics(now);
 
   if (failures.length) {
     await sendEmail({
       subject: "New Comic Notification Cron",
       message: `Failed to send ${failures.length} of ${
-        recipients.length
+        due.length
       } new-comic notification emails:\n\n${failures.join("\n")}`,
     }).catch((e) => console.error(e));
   }

--- a/packages/functions/cron/showNotificationCron.ts
+++ b/packages/functions/cron/showNotificationCron.ts
@@ -1,10 +1,12 @@
-import { differenceInMinutes } from "date-fns";
-
 import {
-  claimPendingNewShows,
   getPendingNewShows,
+  prunePastShows,
 } from "@core/models/newShowQueue";
-import { getShowNotificationRecipients } from "@core/models/showNotification";
+import {
+  getShowNotificationRecipients,
+  markShowNotificationsNotified,
+} from "@core/models/showNotification";
+import { selectDueRecipients } from "@core/notificationDelivery";
 import { renderNewShowsEmail } from "@core/emails/newShowsEmail";
 import { sendEmail, sendHtmlEmail } from "@core/email";
 import {
@@ -16,10 +18,6 @@ import { unsubscribeUrl } from "@core/emails/shared/constants";
 const IS_ACTIVE = process.env.IS_ACTIVE === "1";
 const IS_CRON = process.env.IS_CRON === "1";
 
-// New shows are typically posted over the span of about an hour, so hold the
-// batch until the first queued show is this old. Everything that trickles in
-// while we wait rides along in the same email instead of spamming users.
-const BATCH_WINDOW_MINUTES = 60;
 const SEND_CHUNK_SIZE = 25;
 
 export async function handler() {
@@ -27,84 +25,67 @@ export async function handler() {
     return;
   }
 
-  const pending = await getPendingNewShows();
+  const now = new Date();
+
+  // Retained outbox of upcoming shows; each subscriber is served the ones
+  // queued since their own last digest, no more often than their cadence.
+  const pending = await getPendingNewShows(now);
 
   if (!pending.length) {
-    return {};
-  }
-
-  const now = new Date();
-  const oldestQueuedAt = pending.reduce(
-    (oldest, item) => (item.queuedAt < oldest ? item.queuedAt : oldest),
-    pending[0].queuedAt
-  );
-  const batchAgeMinutes = differenceInMinutes(now, oldestQueuedAt);
-
-  if (batchAgeMinutes < BATCH_WINDOW_MINUTES) {
-    console.log(
-      `Holding batch: ${pending.length} show(s) queued, oldest queued ${batchAgeMinutes}m ago (window is ${BATCH_WINDOW_MINUTES}m)`
-    );
-    return {};
-  }
-
-  // Claim before sending so an overlapping run can't announce the same shows
-  const claimed = await claimPendingNewShows(
-    pending.map((item) => item.queueId)
-  );
-
-  if (!claimed.length) {
-    console.log("Batch already claimed by another run");
-    return {};
-  }
-
-  const claimedIds = new Set(claimed.map((row) => row.id));
-  const nowInSeconds = Math.floor(now.getTime() / 1000);
-
-  // Skip anything that started while the batch was collecting
-  const batch = pending.filter(
-    (item) =>
-      claimedIds.has(item.queueId) && (item.show.timestamp ?? 0) > nowInSeconds
-  );
-
-  if (!batch.length) {
-    console.log("No upcoming shows left in the claimed batch");
+    await prunePastShows(now);
     return {};
   }
 
   const recipients = await getShowNotificationRecipients();
 
-  if (!recipients.length) {
-    console.log(`No subscribers; skipping ${batch.length} queued show(s)`);
+  const due = selectDueRecipients(recipients, pending, now);
+
+  if (!due.length) {
+    await prunePastShows(now);
     return {};
   }
 
-  const shows = batch.map(({ show, room }) => ({
-    timestamp: show.timestamp ?? 0,
-    description: show.description,
-    cover: show.cover,
-    note: show.note,
-    special: show.special,
-    roomName: room?.name ?? null,
-  }));
+  // Advance every due recipient's cursor BEFORE sending so an overlapping cron
+  // run can't announce the same batch twice (mirrors the old claim-before-send
+  // guarantee). A send failure below just means that recipient misses this
+  // batch, exactly as the previous outbox behaved.
+  await markShowNotificationsNotified(
+    due.map(({ recipient }) => recipient.userId),
+    now
+  );
 
-  // The unsubscribe link is personalized per recipient, so render the email
-  // once per recipient with their own opaque token baked into the footer and
-  // the RFC 8058 one-click header.
+  const nowInSeconds = Math.floor(now.getTime() / 1000);
   const failures: string[] = [];
 
-  for (let i = 0; i < recipients.length; i += SEND_CHUNK_SIZE) {
-    const chunk = recipients.slice(i, i + SEND_CHUNK_SIZE);
+  for (let i = 0; i < due.length; i += SEND_CHUNK_SIZE) {
+    const chunk = due.slice(i, i + SEND_CHUNK_SIZE);
     const results = await Promise.allSettled(
-      chunk.map(async ({ email, externalId }) => {
+      chunk.map(async ({ recipient, items }) => {
+        const shows = items
+          .filter(({ show }) => (show.timestamp ?? 0) > nowInSeconds)
+          .map(({ show, room }) => ({
+            timestamp: show.timestamp ?? 0,
+            description: show.description,
+            cover: show.cover,
+            note: show.note,
+            special: show.special,
+            roomName: room?.name ?? null,
+          }));
+
+        if (!shows.length) return;
+
         const unsubUrl = unsubscribeUrl(
-          createUnsubscribeToken(externalId, UnsubscribeChannel.NEW_SHOWS)
+          createUnsubscribeToken(
+            recipient.externalId,
+            UnsubscribeChannel.NEW_SHOWS
+          )
         );
         const { subject, html, text } = await renderNewShowsEmail({
           shows,
           unsubscribeUrl: unsubUrl,
         });
         return sendHtmlEmail({
-          to: email,
+          to: recipient.email,
           subject,
           html,
           text,
@@ -115,22 +96,24 @@ export async function handler() {
 
     results.forEach((result, index) => {
       if (result.status === "rejected") {
-        failures.push(`${chunk[index].email}: ${result.reason}`);
+        failures.push(`${chunk[index].recipient.email}: ${result.reason}`);
       }
     });
   }
 
   console.log(
-    `Announced ${batch.length} show(s) to ${
-      recipients.length - failures.length
-    }/${recipients.length} subscriber(s)`
+    `Announced new shows to ${due.length - failures.length}/${
+      due.length
+    } due subscriber(s)`
   );
+
+  await prunePastShows(now);
 
   if (failures.length) {
     await sendEmail({
       subject: "Show Notification Cron",
       message: `Failed to send ${failures.length} of ${
-        recipients.length
+        due.length
       } new-show notification emails:\n\n${failures.join("\n")}`,
     }).catch((e) => console.error(e));
   }

--- a/packages/functions/settings/index.ts
+++ b/packages/functions/settings/index.ts
@@ -13,6 +13,11 @@ import {
   upsertNewComicNotification,
 } from "@core/models/newComicNotification";
 
+import {
+  DEFAULT_NOTIFICATION_FREQUENCY,
+  NOTIFICATION_FREQUENCIES,
+} from "@core/common/notificationFrequency";
+
 import { generateResponse } from "@core/common/generateResponse";
 import { getAuthIdFromJwtClaim } from "@core/common/getAuthIdFromJwtClaim";
 import { getUserByAuthId } from "@core/models/user";
@@ -79,9 +84,14 @@ export async function get(_evt) {
       comicNotifications: mappedComicNotification,
       showNotification: {
         enabled: showNotification?.[0]?.enabled ?? false,
+        frequency:
+          showNotification?.[0]?.frequency ?? DEFAULT_NOTIFICATION_FREQUENCY,
       },
       newComicNotification: {
         enabled: newComicNotification?.[0]?.enabled ?? false,
+        frequency:
+          newComicNotification?.[0]?.frequency ??
+          DEFAULT_NOTIFICATION_FREQUENCY,
       },
     },
   });
@@ -99,9 +109,11 @@ const comicNotificationPayload = z
   .required();
 const showNotification = z.object({
   enabled: z.boolean(),
+  frequency: z.enum(NOTIFICATION_FREQUENCIES).optional(),
 });
 const newComicNotification = z.object({
   enabled: z.boolean(),
+  frequency: z.enum(NOTIFICATION_FREQUENCIES).optional(),
 });
 
 export async function update(_evt) {
@@ -143,6 +155,7 @@ export async function update(_evt) {
     await upsertShowNotification({
       userId: user.id,
       enabled: showNotification.enabled,
+      frequency: showNotification.frequency,
     });
   }
 
@@ -151,6 +164,7 @@ export async function update(_evt) {
     await upsertNewComicNotification({
       userId: user.id,
       enabled: newComicNotification.enabled,
+      frequency: newComicNotification.frequency,
     });
   }
 

--- a/packages/functions/settings/index.ts
+++ b/packages/functions/settings/index.ts
@@ -14,8 +14,8 @@ import {
 } from "@core/models/newComicNotification";
 
 import {
-  DEFAULT_NOTIFICATION_FREQUENCY,
-  NOTIFICATION_FREQUENCIES,
+  DEFAULT_FREQUENCY_MINUTES,
+  MAX_FREQUENCY_MINUTES,
 } from "@core/common/notificationFrequency";
 
 import { generateResponse } from "@core/common/generateResponse";
@@ -84,14 +84,14 @@ export async function get(_evt) {
       comicNotifications: mappedComicNotification,
       showNotification: {
         enabled: showNotification?.[0]?.enabled ?? false,
-        frequency:
-          showNotification?.[0]?.frequency ?? DEFAULT_NOTIFICATION_FREQUENCY,
+        frequencyMinutes:
+          showNotification?.[0]?.frequencyMinutes ?? DEFAULT_FREQUENCY_MINUTES,
       },
       newComicNotification: {
         enabled: newComicNotification?.[0]?.enabled ?? false,
-        frequency:
-          newComicNotification?.[0]?.frequency ??
-          DEFAULT_NOTIFICATION_FREQUENCY,
+        frequencyMinutes:
+          newComicNotification?.[0]?.frequencyMinutes ??
+          DEFAULT_FREQUENCY_MINUTES,
       },
     },
   });
@@ -107,13 +107,22 @@ const comicNotificationPayload = z
   })
   .strict()
   .required();
+// Any interval is accepted, not just the UI's presets — the cadence is
+// future-proofed as an arbitrary number of minutes (0 = immediately), capped at
+// what the retention window can honour.
+const frequencyMinutes = z
+  .number()
+  .int()
+  .min(0)
+  .max(MAX_FREQUENCY_MINUTES)
+  .optional();
 const showNotification = z.object({
   enabled: z.boolean(),
-  frequency: z.enum(NOTIFICATION_FREQUENCIES).optional(),
+  frequencyMinutes,
 });
 const newComicNotification = z.object({
   enabled: z.boolean(),
-  frequency: z.enum(NOTIFICATION_FREQUENCIES).optional(),
+  frequencyMinutes,
 });
 
 export async function update(_evt) {
@@ -155,7 +164,7 @@ export async function update(_evt) {
     await upsertShowNotification({
       userId: user.id,
       enabled: showNotification.enabled,
-      frequency: showNotification.frequency,
+      frequencyMinutes: showNotification.frequencyMinutes,
     });
   }
 
@@ -164,7 +173,7 @@ export async function update(_evt) {
     await upsertNewComicNotification({
       userId: user.id,
       enabled: newComicNotification.enabled,
-      frequency: newComicNotification.frequency,
+      frequencyMinutes: newComicNotification.frequencyMinutes,
     });
   }
 


### PR DESCRIPTION
## Summary
This PR introduces configurable notification frequency (immediately, weekly, monthly) for the two global digest emails (new shows and new comics). Previously, all subscribers received notifications immediately. The implementation replaces the old "claim and clear" outbox model with a per-user cursor model that respects each subscriber's chosen cadence.

## Key Changes

- **Database Schema**: Added three new tables to support the new notification model:
  - `new_show_queue` - retains queued shows for per-user delivery
  - `new_comic_queue` - retains queued comics for per-user delivery
  - `comic_notification_queue` - tracks per-comic notifications (separate from global digests)
  - Updated `show_notification` and `new_comic_notification` tables with `frequency` and `lastNotifiedAt` fields

- **Notification Delivery Logic**: 
  - Created `notificationDelivery.ts` with `selectDueRecipients()` function that implements per-user cursor logic
  - Recipients only receive items queued after their `lastNotifiedAt`, respecting their chosen cadence
  - "Immediately" frequency still batches items for up to 60 minutes to avoid spam from bursts

- **Frequency Configuration**:
  - Added `notificationFrequency.ts` with `NotificationFrequency` type and validation
  - Defined three frequency options: "immediately", "weekly", "monthly"
  - Default frequency is "immediately" for backward compatibility

- **Cron Job Updates**:
  - Refactored `showNotificationCron.ts` and `newComicNotificationCron.ts` to use new per-user cursor model
  - Removed global batch claiming logic in favor of per-recipient delivery selection
  - Added queue pruning to remove old items beyond retention window (45 days for comics, based on show timestamps)

- **Frontend UI**:
  - Updated `profileSettings.tsx` to display frequency picker for global notifications
  - Added `SegmentedToggle` component for frequency selection
  - Frequency picker only shows when the notification is enabled

- **Settings API**:
  - Updated settings endpoints to handle `frequency` parameter
  - Modified upsert logic to only update provided fields, preventing silent resets of frequency when toggling enabled state

## Implementation Details

- Queue retention is 45 days for comics to ensure monthly subscribers never miss items queued between digests
- Shows are filtered by timestamp to exclude past shows from delivery
- Per-user `lastNotifiedAt` cursor replaces global `notifiedAt` flag, enabling different subscribers to receive the same queued item at different times
- Partial updates in upsert operations prevent unintended overwrites of user preferences

https://claude.ai/code/session_01GYCcagSy6zQpMA9DqBdYHr