### PR TITLE
Add modal dialog for viewing full event lineup

### DIFF
--- a/packages/frontend/src/pages/Reservations/LineUpModal.tsx
+++ b/packages/frontend/src/pages/Reservations/LineUpModal.tsx
@@ -1,0 +1,78 @@
+import { useEffect } from "preact/hooks";
+
+import { Avatar } from "../../components/ui/Avatar";
+import { Eyebrow } from "../../components/ui/Eyebrow";
+import { LineUp } from "../../types";
+
+export function LineUpModal(props: { lineUp: LineUp; onClose: () => void }) {
+  const { lineUp, onClose } = props;
+
+  // Close on Escape and lock body scroll while the modal is open.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKeyDown);
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Show lineup"
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      onClick={onClose}
+    >
+      <div className="absolute inset-0 bg-ink/70" />
+
+      <div
+        className="relative flex max-h-[85vh] w-full max-w-md flex-col overflow-hidden rounded-panel border-hair border-line bg-surface shadow-block-lg"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-4 border-b-hair border-line px-6 py-5">
+          <div>
+            <Eyebrow>The Lineup</Eyebrow>
+            <h2 className="mt-1 font-display text-d-sm leading-none text-text">
+              Tonight's Acts
+            </h2>
+          </div>
+
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close lineup"
+            className="grid size-8 shrink-0 place-items-center rounded-pill border-hair border-line bg-surface font-mono text-body text-muted hover:text-text"
+          >
+            ×
+          </button>
+        </div>
+
+        <ul className="flex flex-col gap-4 overflow-y-auto px-6 py-5">
+          {lineUp.acts.map((act) => (
+            <li key={act.name} className="flex items-center gap-3.5">
+              <Avatar name={act.name} img={act.img} size={48} />
+              <div className="min-w-0">
+                <p className="truncate font-sans text-body font-bold text-text">
+                  {act.name}
+                </p>
+                {act.description && (
+                  <p className="truncate font-mono text-meta text-muted">
+                    {act.description}
+                  </p>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/pages/Reservations/ShowDetails.tsx
+++ b/packages/frontend/src/pages/Reservations/ShowDetails.tsx
@@ -1,7 +1,9 @@
 import { LineUp, Show } from "../../types";
 import { deriveShowDetails } from "../../utils/deriveShowDetails";
+import { useState } from "preact/hooks";
 import { Avatar } from "../../components/ui/Avatar";
 import { Eyebrow } from "../../components/ui/Eyebrow";
+import { LineUpModal } from "./LineUpModal";
 
 export const ShowDetails = (props: { show: Show; lineUp: LineUp }) => {
   const { roomName, max, description } = props.show;
@@ -53,19 +55,38 @@ export const ShowDetails = (props: { show: Show; lineUp: LineUp }) => {
 
 function LineUpDetails(props: { lineUp: LineUp }) {
   const { lineUp } = props;
+  const [isOpen, setIsOpen] = useState(false);
+
+  if (lineUp.acts.length === 0) return null;
 
   return (
-    <div className="mt-5 flex">
-      {lineUp.acts.map((act) => (
-        <span
-          key={act.name}
-          title={act.name}
-          className="-mr-[7px] inline-flex"
-        >
-          <span className="sr-only">{act.name}</span>
-          <Avatar name={act.name} img={act.img} size={30} />
+    <div className="mt-5">
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        aria-label="View full lineup"
+        className="group flex items-center gap-3 rounded-pill outline-none focus-visible:shadow-[3px_3px_0_var(--color-brand)]"
+      >
+        <span className="flex">
+          {lineUp.acts.map((act) => (
+            <span
+              key={act.name}
+              title={act.name}
+              className="-mr-[7px] inline-flex"
+            >
+              <span className="sr-only">{act.name}</span>
+              <Avatar name={act.name} img={act.img} size={30} />
+            </span>
+          ))}
         </span>
-      ))}
+        <span className="font-mono text-meta uppercase tracking-wider text-muted group-hover:text-text">
+          View lineup
+        </span>
+      </button>
+
+      {isOpen && (
+        <LineUpModal lineUp={lineUp} onClose={() => setIsOpen(false)} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
This PR adds an interactive modal dialog that displays the full lineup of acts for an event. Users can now click a "View lineup" button to see detailed information about all performers in a dedicated modal.

## Key Changes
- **New `LineUpModal` component**: Created a new modal component that displays all acts in the lineup with their avatars and descriptions
  - Implements proper accessibility with ARIA attributes (`role="dialog"`, `aria-modal`, `aria-label`)
  - Supports closing via Escape key or clicking outside the modal
  - Locks body scroll while modal is open to prevent background scrolling
  - Displays acts in a scrollable list with avatars, names, and optional descriptions

- **Updated `LineUpDetails` component**: Refactored to use the new modal
  - Converted from static avatar display to an interactive button
  - Added state management to control modal visibility
  - Added early return when lineup is empty
  - Improved UX with hover states and focus-visible styling
  - Maintains the overlapping avatar preview while adding "View lineup" text label

## Implementation Details
- Modal uses fixed positioning with a semi-transparent backdrop overlay
- Click propagation is stopped on the modal content to prevent closing when clicking inside
- Proper cleanup of event listeners and body style restoration on component unmount
- Responsive design with max-width constraints and padding for mobile compatibility
- Uses existing UI components (`Avatar`, `Eyebrow`) for consistency

https://claude.ai/code/session_01MtNB834i2RFP6aY8sBBqoW